### PR TITLE
Add frontier-design / economy-execution model routing (v2.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Beastmode:
 
 **Frontier models design. Cheap models build and validate. The loop learns.**
 
+The routing rule underneath: a task goes to a cheap model exactly when its output can be cheaply verified (tests, schema, contract); frontier models handle work that only judgment can verify — and their real job is *creating verifiability* (contracts, interfaces, verification commands) so as much work as possible becomes cheap-routable.
+
 ## Model Tiers
 
 - **Design tier (frontier):** Claude Fable, Kimi 3, Opus, frontier Codex/GPT — architecture, acceptance contracts, judgment review, escalations

--- a/README.md
+++ b/README.md
@@ -12,30 +12,38 @@ Exact search aliases: **beastmode**, **MofA**, **Mixture of Agents**, **memroos*
 
 Beastmode:
 
-- **Saves money** by routing routine work to cheap models (Qwen/Gwen) while keeping expensive models (Opus, Claude Code, Codex) for judgment and review
+- **Saves money** by routing implementation *and mechanical validation* to economy models (MiniMax M3, Qwen/Gwen) while keeping frontier models (Claude Fable, Kimi 3, Opus, Codex) for design, judgment, and review sign-off
 - **Improves quality** through mandatory acceptance contracts, adversarial review, and merge gates
 - **Gets better over time** via a self-improvement loop that records lessons and promotes repeated patterns into skills/config
 - **Works anywhere** — harness-agnostic, compatible with Ultraswarm, GSD, `delegate_task`, Claude Code subagents, or manual git workflows
 
 ## Core Principle
 
-**Expensive models decide. Cheap models build. The loop learns.**
+**Frontier models design. Cheap models build and validate. The loop learns.**
+
+## Model Tiers
+
+- **Design tier (frontier):** Claude Fable, Kimi 3, Opus, frontier Codex/GPT — architecture, acceptance contracts, judgment review, escalations
+- **Execution tier (economy):** MiniMax M3, Qwen/Gwen — implementation, tests, docs, and mechanical validation (running verification commands, producing pass/fail reports)
+
+See `references/model-routing.md` for the per-phase routing table and escalation ladder.
 
 ## Two Variants
 
-- **Opus-led:** Maximum judgment for product/creative/architecture decisions. Opus directs, Codex challenges, Qwen executes.
-- **Codex-led:** Cost-efficient lead with strong gates. Codex plans and reviews, Qwen executes.
+- **Frontier-led:** Maximum judgment for product/creative/architecture decisions. Fable or Kimi 3 directs (optionally pairing the two — one designs, the other challenges), MiniMax M3/Qwen executes and validates.
+- **Codex-led:** Cost-efficient lead with strong gates. Codex plans and reviews, MiniMax M3/Qwen executes.
 
 ## Quick Start
 
 1. Read `SKILL.md` — the full framework
-2. Choose your variant (Opus-led or Codex-led)
+2. Choose your variant (frontier-led or Codex-led) and map your models to tiers (`references/model-routing.md`)
 3. Choose your harness (Ultraswarm, GSD, delegate_task, Claude Code subagents, or manual git)
-4. Follow the beastmode loop: Preflight → Acceptance Contract → Plan → Delegate → Review → Merge → Self-Improve
+4. Follow the beastmode loop: Preflight → Acceptance Contract → Design (frontier) → Delegate (economy) → Validate (economy) → Review (frontier) → Merge → Self-Improve
 
 ## Files
 
 - `SKILL.md` — The complete beastmode framework (start here)
+- `references/model-routing.md` — Tier definitions, per-phase routing table, design package template, escalation ladder, provider config sketches
 - `references/orchestration-comparison.md` — Evolution from early prototypes to v2.0
 - `references/context-rot-mitigation.md` — MemroOS-style goal-state capsules, compact/resume rules, and MofA decision memory
 - `references/public-sharing-checklist.md` — Guidelines for publishing beastmode skills publicly

--- a/SKILL.md
+++ b/SKILL.md
@@ -2,15 +2,16 @@
 name: beastmode
 description: >
   Multi-agent orchestration framework for high-intensity feature implementation.
-  Combines expensive high-judgment models (Opus/Codex) for planning and review
-  with cheap models (Qwen/Gwen) for routine execution in isolated worktrees,
+  Routes work across model tiers: frontier models (Claude Fable, Kimi 3, Opus/Codex)
+  own design, architecture, and review sign-off, while economy models (MiniMax M3,
+  Qwen/Gwen) handle implementation and mechanical validation in isolated worktrees,
   with a self-improving learning loop that promotes lessons back into skills.
   Harness-agnostic: works with Ultraswarm, GSD, delegate_task, or manual orchestration.
-version: 2.0.0
+version: 2.1.0
 author: Luis Calderon
-tags: [beastmode, orchestration, multi-agent, cost-optimization, self-improving, worktrees]
+tags: [beastmode, orchestration, multi-agent, cost-optimization, model-routing, self-improving, worktrees]
 related_skills: [ultraswarm, gsd, subagent-driven-development, self-improvement]
-agents: [hermes, codex, openclaw, claude-code]
+agents: [hermes, codex, openclaw, claude-code, fable, kimi, minimax]
 ---
 
 # Beastmode: Multi-Agent Orchestration Framework
@@ -21,13 +22,34 @@ Beastmode is a structured approach to multi-agent software development that sepa
 
 ## Core Principle
 
-**Expensive models decide. Cheap models build. The loop learns.**
+**Frontier models design. Cheap models build and validate. The loop learns.**
 
-- **Director/Lead:** High-judgment model (Opus, Claude Code, or Codex) owns intent, architecture, creative judgment, and final sign-off.
-- **Watcher/Reviewer:** Adversarial reviewer (Codex/GSD) challenges plans, gates merges, catches scope creep.
-- **Executor:** Cheap model (Qwen 3.7 Plus / Gwen) handles routine implementation in isolated worktrees.
+- **Director/Lead (Design tier):** Frontier model (Claude Fable, Kimi 3, Opus, or Codex) owns intent, architecture, creative judgment, and final sign-off.
+- **Watcher/Reviewer:** Adversarial reviewer (frontier or mid-tier: Codex/GSD/Kimi 3) challenges plans, gates merges, catches scope creep.
+- **Executor (Execution tier):** Economy model (MiniMax M3, Qwen 3.7 Plus / Gwen) handles routine implementation *and mechanical validation* (running tests, lint, typecheck, diff summaries) in isolated worktrees.
 - **Harness:** Any orchestration tool (Ultraswarm, GSD, `delegate_task`, Claude Code subagents, or manual git workflow).
 - **Memory:** Self-improvement loop records lessons and promotes repeated patterns into skills/config.
+
+## Model Tiers & Routing
+
+Beastmode routes every unit of work to a tier, not a specific model. Pick the best available model in each tier for your environment.
+
+| Tier | Example models | Owns |
+|------|---------------|------|
+| **Design (frontier)** | Claude Fable (`claude-fable-5`), Kimi 3, Claude Opus, Codex/GPT frontier | Intent interpretation, architecture, API/data-model design, tradeoff decisions, acceptance contracts, final review sign-off, escalations |
+| **Execution (economy)** | MiniMax M3, Qwen 3.7 Plus / Gwen, Haiku-class | Implementation, tests, docs, refactors, scripts, **mechanical validation** (run test suites, lint, typecheck, build, produce structured pass/fail reports) |
+
+**Validation is split in two:**
+
+1. **Mechanical validation (cheap):** The executor tier runs verification commands, collects results, and produces a structured report (what passed, what failed, diff stats). This is deterministic work — never spend frontier tokens on it.
+2. **Judgment review (frontier):** The design tier reads the *report + diff*, not the raw logs, and makes the merge decision. One frontier pass per phase, at the gate.
+
+**Routing rules of thumb:**
+- If the output of the task is a *decision*, route to the design tier.
+- If the output is a *diff, artifact, or pass/fail report*, route to the execution tier.
+- If an execution-tier task fails the same acceptance check twice, escalate that task (not the whole phase) to the design tier.
+
+See `references/model-routing.md` for the full per-phase routing table, provider configuration examples, and the escalation ladder.
 
 ## When to Use Beastmode
 
@@ -46,27 +68,27 @@ Use beastmode for complex tasks that need:
 
 ## Two Beastmode Variants
 
-### Variant A: Opus-Led Beastmode
+### Variant A: Frontier-Led Beastmode (Fable / Kimi 3 / Opus)
 
-**Use when:** You have Claude Code / Opus available as the lead and need maximum judgment for product/creative/architecture decisions.
+**Use when:** You have a frontier model available as the lead (Claude Fable, Kimi 3, Claude Code / Opus) and need maximum judgment for product/creative/architecture decisions.
 
 **Role split:**
-- **Director (Opus/Claude Code):** Intent, architecture, creative judgment, final sign-off
-- **Watcher (Codex/GSD):** Adversarial planning, scope/cost review, merge gating
-- **Executor (Qwen/Gwen):** Implementation, tests, docs, scripts, mechanical refactors
+- **Director (Fable / Kimi 3 / Opus):** Intent, architecture, design docs, creative judgment, final sign-off
+- **Watcher (Codex/GSD or a second frontier model):** Adversarial planning, scope/cost review, merge gating — pairing two different frontier models (e.g. Fable designs, Kimi 3 challenges) catches blind spots a single model family misses
+- **Executor (MiniMax M3 / Qwen / Gwen):** Implementation, tests, docs, scripts, mechanical refactors, and mechanical validation (running verification commands, producing pass/fail reports)
 
-**Key rule:** Opus must aggressively avoid spending tokens on routine implementation. Delegate file edits, test writing, docs, refactors, and command execution to Qwen.
+**Key rule:** The frontier lead must aggressively avoid spending tokens on routine implementation *or* on watching test output scroll by. Delegate file edits, test writing, docs, refactors, command execution, and validation runs to the executor tier; the lead only reads the structured validation report and the diff.
 
 ### Variant B: Codex-Led Beastmode
 
-**Use when:** You don't have Opus, or the task doesn't require Opus-level judgment. Codex/GSD leads, with Qwen executing routine work.
+**Use when:** You don't have a frontier lead, or the task doesn't require frontier-level judgment. Codex/GSD leads, with an economy model executing routine work.
 
 **Role split:**
 - **Director/Reviewer (Codex/GSD or current session):** Planning, review, merge decisions
-- **Executor (Qwen/Gwen):** Implementation, tests, docs, scripts
-- **Escalation:** Codex handles security, auth, payments, data-loss, production incidents, or failed Qwen attempts
+- **Executor (MiniMax M3 / Qwen / Gwen):** Implementation, tests, docs, scripts, mechanical validation
+- **Escalation:** Codex or a frontier model (Fable / Kimi 3) handles security, auth, payments, data-loss, production incidents, or failed executor attempts
 
-**Key rule:** Delegate routine work to Qwen, but don't merge until the lead verifies acceptance.
+**Key rule:** Delegate routine work to the executor tier, but don't merge until the lead verifies acceptance.
 
 ## Hard Rules
 
@@ -110,7 +132,7 @@ gsd-verify-work
 gsd-ship
 ```
 
-Let GSD handle planning/phase gates, and delegate routine implementation units to Qwen via Ultraswarm or `delegate_task`.
+Let GSD handle planning/phase gates, and delegate routine implementation units to the executor tier (MiniMax M3 / Qwen) via Ultraswarm or `delegate_task`.
 
 ### Harness 3: delegate_task (Hermes/OpenClaw)
 
@@ -202,12 +224,15 @@ Escalation triggers: <auth/security/payments/data-loss/architecture-uncertainty>
 Self-improvement log path: <.learnings/BEASTMODE.md or project-local path>
 ```
 
-### Step 2: Plan (With Challenge for Opus-Led)
+### Step 2: Design (Frontier Tier — With Challenge)
 
-**For Opus-led:**
-- Opus drafts intent and constraints
-- Codex/GSD turns it into phases and tries to find gaps
-- Opus resolves tradeoffs and approves the phase map
+Design is the highest-leverage phase — this is where frontier tokens are worth spending. Do not skimp here to save cost; a bad design multiplies executor waste downstream.
+
+**For frontier-led (Fable / Kimi 3 / Opus):**
+- The lead drafts intent, constraints, architecture, and interface contracts
+- A second model (Codex/GSD, or the other frontier model) turns it into phases and tries to find gaps
+- The lead resolves tradeoffs and approves the phase map
+- The output is a **design package** the executor can implement without judgment calls: file-level plan, interfaces/signatures, acceptance contract, verification commands
 
 **For Codex-led:**
 - Lead writes the plan directly, or uses harness planning commands
@@ -227,9 +252,20 @@ Use tight task specs. One task should be reviewable in a single diff.
 - **Claude Code:** `Task("<task>")`
 - **Manual:** Executor works in branch, commits changes
 
-### Step 4: Adversarial Review
+### Step 4: Validate (Cheap), Then Review (Frontier)
 
-The lead or Codex reviews the branch diff against the contract.
+**Stage 1 — Mechanical validation (executor tier):** the economy model (MiniMax M3 / Qwen) runs the contract's verification commands and produces a structured report:
+
+```markdown
+## Validation Report <task-id>
+- Commands run: <each command + exit code>
+- Tests: <passed>/<total> (list failures with one-line reasons)
+- Lint/typecheck: pass | fail (<count> issues)
+- Diff stats: <files changed, +/- lines>; unrelated files touched: yes/no
+- Contract checklist: <each acceptance item: met / not met / can't verify>
+```
+
+**Stage 2 — Judgment review (frontier tier):** the lead or Codex reviews the *report + diff* against the contract. Frontier tokens go to reading the diff and making the call, not to re-running or watching tests.
 
 **Review commands:**
 ```bash
@@ -297,16 +333,17 @@ The self-improvement loop writes **notes only** during a beastmode run. Any last
 
 ## Cost Discipline
 
-### Opus-Led Cost Rules
+### Frontier-Led Cost Rules (Fable / Kimi 3 / Opus)
 
-**Keep Opus for:**
+**Keep the frontier tier for:**
 - Interpreting user intent
 - Product/creative judgment
-- Architecture tradeoffs
-- Final review
+- Architecture tradeoffs and design packages
+- Judgment review of validation reports + diffs
+- Final sign-off
 - Escalation decisions
 
-**Move to Qwen/Gwen:**
+**Move to MiniMax M3 / Qwen / Gwen:**
 - Code generation
 - Tests
 - Docs
@@ -315,13 +352,20 @@ The self-improvement loop writes **notes only** during a beastmode run. Any last
 - Asset assembly
 - Repetitive refactors
 - Command execution
+- **Mechanical validation** (running test suites, lint, typecheck, build; summarizing results into a validation report)
 
-**Use Codex for:**
+**Use Codex (or the second frontier model) for:**
 - GSD planning
 - Adversarial scope/cost review
 - Merge gating
 - High-risk analysis
-- Debugging failed Qwen attempts
+- Debugging failed executor attempts
+
+**Anti-patterns that burn frontier tokens:**
+- Frontier lead re-running tests the executor already ran
+- Frontier lead reading raw test/lint output instead of the validation report
+- Frontier lead writing boilerplate ("just this once") because delegation feels slow
+- Sending the executor an underspecified design so the frontier lead has to answer clarifying questions mid-implementation
 
 ### Codex-Led Cost Rules
 
@@ -330,10 +374,10 @@ The self-improvement loop writes **notes only** during a beastmode run. Any last
 - Adversarial review
 - Security/auth/payments/data-loss risk
 - Production incidents
-- Failed Qwen attempts
+- Failed executor attempts
 
-**Move to Qwen/Gwen:**
-- Everything else (implementation, tests, docs, refactors, scripts, commands)
+**Move to MiniMax M3 / Qwen / Gwen:**
+- Everything else (implementation, tests, docs, refactors, scripts, commands, mechanical validation)
 
 ## Required Final Report
 
@@ -341,26 +385,26 @@ End every beastmode run with:
 
 ```text
 ✅ Beastmode complete: <goal>
-Variant: opus-led | codex-led
+Variant: frontier-led | codex-led
 Harness: <ultraswarm/gsd/delegate_task/claude-code/manual>
 Phases completed: <n>
 Director / watcher / executor split: <summary>
-Models: Opus <x%>, Codex/GPT <y%>, Gwen/Qwen <z%>
+Models: Frontier (Fable/Kimi 3/Opus) <x%>, Codex/GPT <y%>, Executor (MiniMax M3/Qwen) <z%>
 Token/cost report: <harness report or estimate>
-Verification: <commands and results>
+Verification: <commands and results, per validation report>
 Self-improvement: <learning entry path + promoted updates, if any>
 Merge status: <merged/branch ready/blocked>
 ```
 
 ## Choosing Your Variant
 
-**Use Opus-led when:**
-- You have Claude Code / Opus available
+**Use frontier-led when:**
+- You have a frontier model available (Claude Fable, Kimi 3, Claude Code / Opus)
 - The task requires maximum product/creative/architecture judgment
-- You're willing to pay for Opus-level decisions but want to minimize Opus implementation spend
+- You're willing to pay for frontier-level design decisions but want implementation and validation on the cheap tier
 
 **Use Codex-led when:**
-- You don't have Opus, or the task doesn't require Opus-level judgment
+- You don't have a frontier lead, or the task doesn't require frontier-level judgment
 - Codex/GSD is sufficient for planning and review
 - You want the cheapest possible lead with strong gates
 
@@ -372,12 +416,14 @@ Merge status: <merged/branch ready/blocked>
 
 ## Escalation Rules
 
-Escalate from Qwen/Gwen to Codex/Opus when:
+Escalate from the executor tier (MiniMax M3 / Qwen / Gwen) to the frontier tier (Fable / Kimi 3 / Opus / Codex) when:
 - Security, auth, payments, data-loss, legal/financial data, or production incident risk appears
 - The work requires non-obvious architecture tradeoffs
-- Qwen fails the same acceptance check twice
+- The executor fails the same acceptance check twice
 - The diff is too broad to review cheaply
 - The user explicitly asks for frontier reasoning
+
+Escalate a *task*, not the whole phase — the rest of the phase keeps running on the cheap tier. See `references/model-routing.md` for the full escalation ladder.
 
 Escalation does not skip self-improvement. Record why the cheap route failed and whether the routing rule should change.
 
@@ -438,6 +484,7 @@ See `references/context-rot-mitigation.md` for full details on architectural fix
 
 ## References
 
+- **Model routing:** See `references/model-routing.md` for the per-phase tier routing table, provider configuration examples (Fable, Kimi 3, MiniMax M3), the mechanical-vs-judgment validation split, and the escalation ladder.
 - **Context rot mitigation:** See `references/context-rot-mitigation.md` for detailed analysis of context accumulation, architectural fixes, and monitoring strategies.
 - **Orchestration comparison:** See `references/orchestration-comparison.md` for the evolution from early prototypes to the current harness-agnostic beastmode.
 - **Public sharing checklist:** See `references/public-sharing-checklist.md` for sanitization guidelines when publishing beastmode skills publicly.

--- a/SKILL.md
+++ b/SKILL.md
@@ -39,17 +39,22 @@ Beastmode routes every unit of work to a tier, not a specific model. Pick the be
 | **Design (frontier)** | Claude Fable (`claude-fable-5`), Kimi 3, Claude Opus, Codex/GPT frontier | Intent interpretation, architecture, API/data-model design, tradeoff decisions, acceptance contracts, final review sign-off, escalations |
 | **Execution (economy)** | MiniMax M3, Qwen 3.7 Plus / Gwen, Haiku-class | Implementation, tests, docs, refactors, scripts, **mechanical validation** (run test suites, lint, typecheck, build, produce structured pass/fail reports) |
 
+**The routing principle: verification cost, not task type.**
+
+A task is safe for a cheap model exactly when its output can be **cheaply and objectively verified** — tests pass, schema validates, the diff matches a concrete spec. A task needs a frontier model when verification is expensive or subjective — "is this the right architecture?", "does this match user intent?". Phase labels (design/implement/validate) are just the common case of this rule, not the rule itself.
+
+This reframes the frontier model's job: **its primary output is not code or even plans — it is verifiability.** The design phase converts an unverifiable goal ("build the feature well") into verifiable tasks (concrete interfaces + acceptance contract + verification commands). Once that conversion happens, the cheap tier can do everything downstream, because failures are caught by the verifier, not by expensive review.
+
+**Routing decision, per task:**
+1. Is there a cheap objective verifier for this task's output? → **Economy tier**, cheap-first cascade (retry once on failure, then escalate).
+2. No verifier exists? → Don't route it to frontier by default. First ask: **can the frontier tier create a verifier** (tests, contract, checklist) and then delegate? Only work that resists verifier-creation — genuine judgment calls — is done directly by the frontier model.
+
 **Validation is split in two:**
 
 1. **Mechanical validation (cheap):** The executor tier runs verification commands, collects results, and produces a structured report (what passed, what failed, diff stats). This is deterministic work — never spend frontier tokens on it.
 2. **Judgment review (frontier):** The design tier reads the *report + diff*, not the raw logs, and makes the merge decision. One frontier pass per phase, at the gate.
 
-**Routing rules of thumb:**
-- If the output of the task is a *decision*, route to the design tier.
-- If the output is a *diff, artifact, or pass/fail report*, route to the execution tier.
-- If an execution-tier task fails the same acceptance check twice, escalate that task (not the whole phase) to the design tier.
-
-See `references/model-routing.md` for the full per-phase routing table, provider configuration examples, and the escalation ladder.
+See `references/model-routing.md` for the verification-cost routing rule in full, the per-phase routing table it implies, provider configuration examples, and the escalation ladder.
 
 ## When to Use Beastmode
 

--- a/references/model-routing.md
+++ b/references/model-routing.md
@@ -1,6 +1,23 @@
 # Model Routing: Frontier Design, Economy Execution
 
-This reference defines how beastmode routes work across model tiers. The core idea: **the cost of a token should match the leverage of the decision it produces.** Design decisions have compounding downstream effects — pay for the best judgment available. Implementation and mechanical validation are verifiable against a contract — buy them at the lowest price that passes the gate.
+This reference defines how beastmode routes work across model tiers.
+
+## The Routing Principle: Verification Cost
+
+Don't route by task *type* — route by how cheaply the task's output can be **verified**.
+
+- **Cheap objective verifier exists** (tests pass, schema validates, lint clean, diff matches a concrete spec) → economy model. If it produces garbage, the verifier catches it for pennies; the worst case is a bounded retry, not a shipped mistake.
+- **Verification is expensive or subjective** ("is this the right architecture?", "does this match what the user actually wants?", "is this security-sensitive change sound?") → frontier model. Here a wrong output is only caught by expensive judgment, so the judgment should happen *once, up front*, in the generation itself.
+
+This reframes what the frontier model is *for*. Its primary output is not code, and not even plans — **it is verifiability**. Design, in beastmode terms, is the act of converting an unverifiable goal ("build this feature well") into verifiable tasks: concrete interfaces, an acceptance contract, executable verification commands, an out-of-scope list. Every hour of frontier design that makes one more task cheaply verifiable moves that task — and all its retries — permanently onto the cheap tier.
+
+Three consequences fall out of the principle:
+
+1. **Cheap-first cascade.** For any task with a verifier, default to the cheapest model and escalate only on verified failure (see Escalation Ladder). Never pre-route to frontier "because it's important" — importance is handled by the verifier and the gate, not by the generation model.
+2. **When no verifier exists, the first question is not "which model does the work?" but "can the frontier model create a verifier?"** Writing characterization tests, tightening the contract, or producing a review checklist is usually cheaper than having the frontier model do the task — and it pays off on every future task of the same shape.
+3. **Frontier review reads compressed evidence, not raw output.** Judgment is expensive; spend it on the decision (report + diff), never on re-deriving the evidence (logs, test runs).
+
+The per-phase table below is what this principle implies for a standard beastmode run — it's the default mapping, not the rule. When a task doesn't fit the table, apply the principle directly.
 
 ## Tier Definitions
 
@@ -59,13 +76,15 @@ Validation splits into two stages routed to different tiers:
 
 Why this split works: mechanical validation is where naive setups burn frontier tokens (long tool outputs, test logs, retries). Piping raw logs into a frontier model is the single most common beastmode cost leak. The report compresses hundreds of KB of logs into <2 KB of decision-relevant signal.
 
-## Escalation Ladder
+## Escalation Ladder (Cheap-First Cascade)
 
-Escalate one rung at a time, per *task* (the rest of the phase stays on the cheap tier):
+Every verifiable task starts at the bottom and climbs only on *verified* failure, per *task* (the rest of the phase stays on the cheap tier):
 
-1. **Retry on economy tier** with the failure appended to the task spec (one retry max).
-2. **Escalate to frontier for diagnosis only:** frontier reads the failure + diff, writes a corrected task spec, hands back to economy tier.
+1. **Retry on economy tier** with the verifier's failure output appended to the task spec (one retry max).
+2. **Escalate to frontier for diagnosis only:** frontier reads the failure + diff, writes a corrected task spec — often this means tightening the verifier or the design package, which is the real fix — then hands back to economy tier.
 3. **Escalate to frontier for execution:** frontier implements the task itself. Reserved for: second identical acceptance failure, security/auth/payments/data-loss surface, non-obvious architecture tradeoffs, or explicit user request.
+
+Rung 2 is the workhorse. Most executor failures are spec failures in disguise — the frontier model fixing the *spec* is cheaper than the frontier model doing the *work*, and it upgrades every similar future task.
 
 Automatic escalation triggers (skip the ladder, go straight to frontier):
 - Security, auth, payments, data-loss, legal/financial data, production incidents

--- a/references/model-routing.md
+++ b/references/model-routing.md
@@ -1,0 +1,114 @@
+# Model Routing: Frontier Design, Economy Execution
+
+This reference defines how beastmode routes work across model tiers. The core idea: **the cost of a token should match the leverage of the decision it produces.** Design decisions have compounding downstream effects — pay for the best judgment available. Implementation and mechanical validation are verifiable against a contract — buy them at the lowest price that passes the gate.
+
+## Tier Definitions
+
+| Tier | Role | Example models | Cost profile |
+|------|------|---------------|--------------|
+| **Frontier (design)** | Architecture, product judgment, review sign-off | Claude Fable (`claude-fable-5`), Kimi 3, Claude Opus, frontier GPT/Codex | Expensive per token; used in short, high-leverage bursts |
+| **Economy (execution)** | Implementation, tests, docs, mechanical validation | MiniMax M3, Qwen 3.7 Plus / Gwen, Haiku-class | 10–50× cheaper; used for the bulk of tokens |
+
+Model names are examples, not requirements — beastmode routes to *tiers*. Substitute whatever frontier and economy models your environment provides. Verify exact model IDs with your provider/router (OpenRouter, direct APIs, local serving) before configuring; provider-specific IDs change frequently.
+
+**Two-frontier pairing:** When you have access to two frontier models from different families (e.g. Fable + Kimi 3), use one as Director and the other as adversarial Watcher. Cross-family review catches blind spots that same-family self-review misses, at the cost of one extra frontier pass per phase.
+
+## Per-Phase Routing Table
+
+| Beastmode step | Work | Tier | Notes |
+|---|---|---|---|
+| 0. Preflight | Repo status, harness checks | Economy (or scripted) | Pure command execution |
+| 1. Acceptance contract | Write goal/non-goals/verification/escalation triggers | **Frontier** | The contract is the executor's spec — ambiguity here is paid for many times downstream |
+| 2. Design | Architecture, interfaces, file-level plan, phase map | **Frontier** | Highest-leverage spend in the whole run. Output a *design package* (see below) |
+| 2b. Design challenge | Adversarial gap-finding on the plan | **Frontier** (second model) or Codex | Cross-family challenge preferred |
+| 3. Implementation | Code, tests, docs, refactors, scripts | Economy | One task = one reviewable diff |
+| 4a. Mechanical validation | Run verification commands, collect results, write validation report | Economy | Deterministic; never frontier |
+| 4b. Judgment review | Read validation report + diff, accept/reject against contract | **Frontier** | One pass per phase, at the gate |
+| 5. Merge | Execute merge commands after approval | Economy (or scripted) | Decision already made in 4b |
+| 6. Self-improvement | Append learning entry | Economy drafts, frontier approves promotions | Notes are cheap; changing routing rules is a judgment call |
+
+## The Design Package
+
+The design phase must produce an artifact the executor can implement **without judgment calls**. If the executor has to make an architecture decision mid-task, the design package was incomplete — that's a design-tier failure, and it should be recorded in the self-improvement log.
+
+A design package contains:
+
+```markdown
+# Design Package: <feature>
+## Intent
+<user-visible outcome, one paragraph>
+## Architecture decisions (already made — do not revisit)
+- <decision>: <choice> because <reason>
+## File-level plan
+- <path>: <create/modify> — <what goes here>
+## Interfaces / signatures
+<function signatures, API shapes, schema definitions — concrete enough to code against>
+## Acceptance contract
+<goal, non-goals, verification commands, manual QA, escalation triggers>
+## Out of scope
+<explicitly deferred items so the executor doesn't "helpfully" add them>
+```
+
+## Mechanical vs. Judgment Validation
+
+Validation splits into two stages routed to different tiers:
+
+**Stage 1 — Mechanical (economy):** run every verification command in the contract; capture exit codes and failures; compute diff stats; check each contract item as met / not met / can't verify; emit the structured Validation Report (format in SKILL.md Step 4). No opinions — just evidence.
+
+**Stage 2 — Judgment (frontier):** read the report and the diff. Ask: does this diff *actually* satisfy the intent, not just the checklist? Any scope creep, security smells, decisions the executor wasn't authorized to make? Accept, reject with specific fixes (back to economy tier), or escalate.
+
+Why this split works: mechanical validation is where naive setups burn frontier tokens (long tool outputs, test logs, retries). Piping raw logs into a frontier model is the single most common beastmode cost leak. The report compresses hundreds of KB of logs into <2 KB of decision-relevant signal.
+
+## Escalation Ladder
+
+Escalate one rung at a time, per *task* (the rest of the phase stays on the cheap tier):
+
+1. **Retry on economy tier** with the failure appended to the task spec (one retry max).
+2. **Escalate to frontier for diagnosis only:** frontier reads the failure + diff, writes a corrected task spec, hands back to economy tier.
+3. **Escalate to frontier for execution:** frontier implements the task itself. Reserved for: second identical acceptance failure, security/auth/payments/data-loss surface, non-obvious architecture tradeoffs, or explicit user request.
+
+Automatic escalation triggers (skip the ladder, go straight to frontier):
+- Security, auth, payments, data-loss, legal/financial data, production incidents
+- The executor proposes changing an interface defined in the design package
+
+Every escalation gets a self-improvement entry: why the cheap route failed, and whether the routing rule or the design-package template should change.
+
+## Configuration Sketches
+
+### Ultraswarm
+
+Map tiers to providers so `--provider auto` routes by task type:
+
+```yaml
+# ultraswarm config sketch — adapt to your installed version
+providers:
+  design:
+    model: claude-fable-5        # or kimi-3 via your router
+    use_for: [plan, review, escalation]
+  execute:
+    model: minimax-m3            # via OpenRouter/direct API — verify exact ID
+    use_for: [implement, test, docs, validate]
+```
+
+```bash
+ultraswarm plan "<goal>" --repo . --provider design --mode gsd
+ultraswarm run "<phase>" --repo . --provider execute --mode gsd
+ultraswarm qa <task-id>          # runs on execute tier; report reviewed by design tier
+```
+
+### Claude Code subagents
+
+Lead session runs on the frontier model; delegate execution to a cheaper subagent model where the harness supports per-agent model selection (e.g. a `.claude/agents/executor.md` with a cheap `model:` in its frontmatter, or the Task tool's model override).
+
+### delegate_task / manual
+
+Run the lead conversation on the frontier model. For each executor task, call the economy model's API/CLI with the design package + task spec as the full prompt, and require the commit + validation report as the only output.
+
+## Cost Sanity Check
+
+After each run, the final report's model split should look roughly like:
+
+- **Frontier: 10–25% of tokens** (design, challenge, judgment reviews, escalations)
+- **Economy: 75–90% of tokens** (implementation, validation, merges)
+
+If frontier share exceeds ~30%, something is leaking — usually raw logs reaching the lead, underspecified design packages causing back-and-forth, or the lead writing code. Record the leak in the self-improvement log and fix the routing rule.


### PR DESCRIPTION
## Summary

Upgrades beastmode so frontier models (Claude Fable, Kimi 3, Opus) handle design while cheap models (MiniMax M3, Qwen/Gwen) handle implementation and validation.

### Changes

- **New "Model Tiers & Routing" section in `SKILL.md`** — defines a Design (frontier) tier and an Execution (economy) tier, with routing rules of thumb: decisions → frontier, diffs/artifacts/pass-fail reports → economy.
- **Variant A renamed to Frontier-Led (Fable / Kimi 3 / Opus)** — includes a two-frontier pairing pattern where one frontier model designs and a second (different family) adversarially challenges.
- **Validation split in two** — Step 4 now has Stage 1 mechanical validation on the economy tier (run tests/lint/typecheck, emit a structured Validation Report) and Stage 2 judgment review on the frontier tier (reads report + diff only, never raw logs).
- **Design phase upgraded** — Step 2 now requires a "design package" (architecture decisions, file-level plan, interfaces, acceptance contract) concrete enough for the executor to implement without judgment calls.
- **New `references/model-routing.md`** — tier definitions, per-phase routing table, design package template, three-rung escalation ladder (retry cheap → frontier diagnosis → frontier execution), provider config sketches (Ultraswarm, Claude Code subagents, delegate_task), and a cost sanity check (frontier share should stay under ~25–30% of tokens).
- **Updated cost discipline, escalation rules, final report format, and README** to use tier language and the new model names; added frontier-token anti-patterns (lead re-running tests, reading raw logs, writing boilerplate).

Version bumped to 2.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EUdPJEANuMqoP1wJcdZsE

---
_Generated by [Claude Code](https://claude.ai/code/session_012EUdPJEANuMqoP1wJcdZsE)_