### PR TITLE
Add beastmode-pi harness adapter (pi-goal + pi-dynamic-workflows + pi-loop-police + pi-permission-system + rpiv-todo + pi-telegram)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Beastmode repo gitignore
+
+# Pi package install state (user-level, never committed)
+.pi/
+.pnpm-store/
+
+# Local skill discovery copy (alternative location; the canonical home is pi/)
+.agents/skills/
+
+# OS / editor noise
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+*~
+.idea/
+.vscode/
+
+# Node — only if a pi package build step is added later
+node_modules/
+*.log

--- a/pi/SKILL.md
+++ b/pi/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: beastmode-pi
+description: Pi-specific harness adapter for the universal Beastmode MofA orchestration framework (see the `beastmode` skill, v2.1). Composes five installed pi packages into the universal loop — pi-goal as the in-session goal engine, pi-dynamic-workflows as the fan-out / model-router, pi-loop-police as the anti-spin circuit breaker, pi-permission-system as the worker-contract enforcer, rpiv-todo + pi-telegram as live visibility. Use when Luis asks for beastmode, a Mixture-of-Agents run, autonomous goal execution, planner/worker/watcher, or a phase takeover inside a pi session.
+version: 1.0.0
+author: Luis Calderon
+tags: [beastmode, mofa, pi, orchestration, multi-agent, model-routing, worktrees, self-improving]
+related_skills: [beastmode, gsd]
+source_repo: https://github.com/lac5q/beastmode/blob/main/pi/SKILL.md
+---
+
+# Beastmode Pi — Pi Harness Adapter
+
+This skill is **only the harness mechanics**. The framework, tier-routing
+rule, verifier-first design principle, and self-improvement loop live in the
+canonical `beastmode` skill (v2.1) — load it first and follow it. This
+adapter tells you which pi packages implement which role and how to wire
+them together.
+
+| Universal Beastmode role | Pi implementation |
+|---|---|
+| Director / Lead (frontier tier) | The pi session itself — frontier model stays in charge |
+| Watcher (adversarial review) | `pi-dynamic-workflows` `verify()` / `judgePanel()`, or the built-in `/adversarial-review` workflow |
+| Worker (economy tier) | `pi-dynamic-workflows` `agent()` with `tier: "small"`/`"medium"` or an external lane (Qwen / MiniMax API / Droid MiniMax) routed via `model:` |
+| Loop engine (continues until done) | `@narumitw/pi-goal` — `/goal`, `goal_complete`, `goal_blocked` |
+| Anti-spin circuit breaker | `pi-loop-police` (passive, always on) |
+| Worker-contract enforcer | `@gotgenes/pi-permission-system` project config (path / external_directory / bash deny + ask surfaces) |
+| Live progress visibility | `@juicesharp/rpiv-todo` overlay (TUI) and `/workflows` navigator |
+| Remote supervision | `@llblab/pi-telegram` proactive push (only if `/telegram-setup` was completed) |
+| Durable goal record | Optional: any goal store (MemRoOS `/api/gsd/goal`, plain file, etc.). Beastmode itself does **not** require a specific store. |
+| Self-improvement log | `<repo>/.learnings/BEASTMODE.md` (universal) — consumer projects (e.g., memroos) may overlay `.beastmode/learnings/<date>-<slug>.md` as a house flavor |
+
+## Preflight (per host)
+
+```bash
+pi --version                    # must be >= 0.80.6 (pi-goal requires it)
+pi list                         # must include all six packages; install missing:
+pi install npm:@narumitw/pi-goal \
+  npm:@quintinshaw/pi-dynamic-workflows \
+  npm:pi-loop-police npm:@gotgenes/pi-permission-system \
+  npm:@juicesharp/rpiv-todo npm:@llblab/pi-telegram
+```
+
+Telegram supervision is optional. `/telegram-setup` is interactive and needs a
+bot token from `@BotFather`; if it was never completed, skip telegram silently
+rather than blocking a run on it.
+
+## Lane smoke gates (mirror `beastmode-cloud`)
+
+Before routing work to an external cheap lane, prove it is live. If a lane
+fails its smoke gate, report it as installed-but-not-live and route to a
+different lane (or the pi-native tier).
+
+```bash
+# Qwen lane
+~/.local/bin/qwen-agent --dangerously-skip-permissions -p "Reply with exactly: QWEN OK"
+
+# Direct MiniMax API lane (MINIMAX_API_KEY in env; never print the key)
+curl -sS https://api.minimax.io/v1/chat/completions \
+  -H "Authorization: Bearer $MINIMAX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"MiniMax-M3","thinking":{"type":"disabled"},"messages":[{"role":"user","content":"Reply with exactly: MINIMAX OK"}],"max_completion_tokens":20,"temperature":0}'
+
+# Droid MiniMax lane
+~/.local/bin/droid exec --model minimax-m3 "Reply with exactly: MINIMAX OK"
+```
+
+Pi-native tiers (`small` / `medium` / `big` via `/workflows-models`) need no
+smoke gate. Prefer pi-native routing for the director and watcher turns;
+prefer external CLI lanes for the bulk cheap-worker execution you already pay
+for. The verifier-first rule from the universal skill governs everything:
+if a cheap lane cannot produce a verifiable artifact cheaply, escalate to
+the frontier tier.
+
+## Operating loop
+
+1. **Load the universal skill first.** Read `beastmode` v2.1 — Step 0
+   (preflight), Step 1 (acceptance contract), Step 2 (design with
+   challenge). This adapter does not redefine those.
+
+2. **Optional durable goal record.** Beastmode itself does not require a
+   specific goal store. If the consumer repo overlays one (e.g., memroos
+   posts to `/api/gsd/goal`), call it; if absent, write the acceptance
+   contract to a file (`GOAL.md` at the repo root is the universal fallback)
+   and proceed.
+
+3. **Write the acceptance contract** in the universal format (see the
+   `beastmode` skill, Step 1). Capture: goal / non-goals / user-visible
+   acceptance / files likely touched / verification commands / manual QA /
+   escalation triggers / self-improvement log path.
+
+4. **Start the loop engine.** Activate pi-goal with the contract condensed
+   into a `/goal` invocation:
+
+   ```
+   /goal --tokens 100k <goal statement + numbered done-when criteria>
+   ```
+
+   pi-goal auto-continues from pi's idle boundary until the model calls
+   `goal_complete({goal_id, summary})`. Summaries that contradict evidence
+   ("tests still failing") are rejected by the tool — don't try to word
+   around it. A true impasse (same blocker on 3 consecutive goal turns, with
+   concrete evidence) goes through `goal_blocked({goal_id, reason, evidence,
+   repeated_turns})`. Budget exhaustion (`budget_limited`) is a normal stop
+   state: report spent vs remaining and propose a resume slice.
+
+5. **Fan out with pi-dynamic-workflows** for any phase where the work is
+   wider than a single agent (multi-file audits, >3 independent slices,
+   parallel reviews, codebase-wide research). Write a deterministic JS
+   orchestration script using `agent()` / `parallel()` / `pipeline()` /
+   `phase()` with these conventions:
+
+   - Route workers to `tier: "small"`/`"medium"` or an exact
+     `model: "provider/modelId"` for a proven external lane
+   - Set `isolation: "worktree"` whenever workers edit, so parallel edits do
+     not collide
+   - Cross-check with `verify()` or `judgePanel()` as the watcher; or use
+     the built-in `/adversarial-review` workflow directly
+   - Add `checkpoint()` for any human-approval gate you want journaled into
+     the workflow's resume log
+   - Set phase budgets on expensive phases; use `budget` to inspect real
+     spend mid-run
+   - The `/workflows` navigator shows phases, agents, models, tokens, cost,
+     and live tok/s; `agent()` accepts a JSON Schema `schema:` for typed
+     results so cross-checking is structural
+
+   Every worker prompt MUST carry the universal beastmode worker contract:
+   exact repo path, objective, allowed files/directories, allowed commands,
+   forbidden commands (commit, push, delete outside scope, publish, send
+   email, access secrets, change cloud config), required output (summary,
+   unified diff or exact files changed, commands run, verification notes,
+   risks/blockers). Workers never commit or push — the director merges.
+
+6. **Guardrails are already on.** loop-police needs no configuration; if it
+   fires repeatedly on one subtask, shrink the slice or switch worker lane.
+   The project permission config (see `references/pi-permission-config.md`
+   for a starter) denies secret paths and forces `ask` on `git push`,
+   `git commit`, `rm -rf`, `sudo`, publish-class commands; the director
+   (human or pi session) approves merges; workers physically cannot reach
+   secrets or leave the repo. `/goal --tokens` plus workflow phase budgets
+   bound total spend.
+
+7. **Visibility.** In the TUI, rpiv-todo keeps a live checklist and
+   `/workflows` opens the run navigator. If telegram was set up, proactive
+   push mirrors completed checkpoints to the phone; never paste tokens,
+   diffs containing secrets, or private data into telegram-bound text.
+
+## Completion contract (on `goal_complete`)
+
+Beastmode's universal artifacts, written in this order:
+
+1. **Worker run record** — harness-specific. With pi-dynamic-workflows, this
+   is the workflow run journal (id, phases, agent transcripts, token / cost
+   per agent, real `usage` blocks) — export or reference it; the universal
+   shape is `{"id", "model", "stop_reason", "usage": {"input_tokens",
+   "output_tokens"}}`. For runs that used external CLI lanes (qwen-agent,
+   droid exec, MiniMax curl), persist a `meta.json` next to the run record
+   with the same shape, populated from the lane's reported usage.
+2. **Acceptance contract delta** — update the contract file (the one from
+   Step 3) with actual vs planned for each acceptance bullet, and the
+   verification commands that passed.
+3. **Self-improvement entry** — append a section to
+   `<repo>/.learnings/BEASTMODE.md` (universal) with: `## Role Routing`,
+   `## Acceptance Checks`, `## Result`, `## What Worked`, `## What Failed /
+   Drifted`, `## Routing Rule To Change` (Yes/No + what). If every watcher
+   tier failed, record the code/test/build evidence and leave the goal
+   active — never claim beastmode validation without a watcher.
+4. **Optional: post completion** to the consumer repo's durable goal store
+   if one is configured.
+5. **Report**: goal statement, lane, acceptance criteria, verification
+   evidence, run-record path(s), self-improvement entry path, next action.
+
+Consumer projects may overlay additional house artifacts (e.g., memroos
+also writes `.beastmode/worker-runs/<UTCts>-<slug>/{prompt,output,meta}`
+files). The universal contract above is the floor; consumer extras are
+fine.
+
+## Hard rules (universal, non-negotiable)
+
+- The director (pi session, always a frontier-tier model) reviews and
+  applies all worker output. Workers never commit, push, hold secrets, or
+  claim final verification.
+- The verifier-first rule beats cost optimization: a cheap lane with a
+  cheap verifier always wins over a frontier lane doing the same work.
+- Never unset strict memory, widen permission config, or disable
+  loop-police to make a run pass. A blocked run is a finding, not a bug
+  in the guardrail.
+- No watcher, no "validated": evidence-only close-out, goal stays active.
+- Budget exhaustion (`budget_limited`) is a normal stop state: report
+  spent vs remaining and propose the resume slice, do not silently
+  continue.
+
+## See also
+
+- `beastmode` (v2.1) — the canonical framework this adapter implements
+- `references/pi-permission-config.md` — starter permission-system config
+  encoding the worker contract
+- `references/context-rot-mitigation.md` (in the universal skill) — keep
+  orchestrator context small; route bulk work into pi-dynamic-workflows so
+  the director context only carries summaries
+- `references/model-routing.md` (in the universal skill) — the
+  verification-cost routing rule that governs tier choice

--- a/pi/references/pi-permission-config.md
+++ b/pi/references/pi-permission-config.md
@@ -1,0 +1,89 @@
+# Permission Config Starter (pi-permission-system)
+
+A project-level `@gotgenes/pi-permission-system` config that encodes the
+universal Beastmode worker contract: workers (cheap subagents spawned via
+`pi-dynamic-workflows`) physically cannot read secret paths or run
+publishing / destructive commands without an explicit human `ask`.
+
+Save this at `<repo>/.pi/extensions/pi-permission-system/config.json`.
+Project config overrides global config at `~/.pi/agent/extensions/pi-permission-system/config.json`.
+
+## Starter config
+
+```json
+{
+  "permission": {
+    "*": "allow",
+    "path": {
+      "*": "allow",
+      "*.env": "deny",
+      "*.env.*": "deny",
+      ".env.local": "deny",
+      "**/.ssh/*": "deny",
+      "**/.memroos/agent-keys/*": "deny",
+      "**/.memroos/*.env": "deny",
+      "**/*.pem": "deny",
+      "**/*.key": "deny",
+      "**/auth.json": "deny",
+      ".env.example": "allow",
+      "**/.env.example": "allow"
+    },
+    "external_directory": "ask",
+    "bash": {
+      "*": "allow",
+      "git push *": "ask",
+      "git push": "ask",
+      "git commit *": "ask",
+      "git commit": "ask",
+      "rm -rf *": "ask",
+      "sudo *": "ask",
+      "gh pr create *": "ask",
+      "gh release *": "ask",
+      "npm publish *": "ask",
+      "curl *minimax*": "ask"
+    }
+  }
+}
+```
+
+## Reading the rules
+
+Surfaces evaluate **most-restrictive-wins** in this order:
+`path` (cross-cutting, all file access) → `external_directory` (CWD
+boundary) → per-tool patterns → `bash` (shell commands).
+
+Within a surface, **last matching rule wins**, so put broad catch-alls
+first and specific overrides after. A `path` deny cannot be overridden by
+a per-tool allow — that is what makes it the right place to protect
+secrets from every tool at once.
+
+The `path` surface matches both the path as referenced and its canonical
+(symlink-resolved) form, so symlink aliases cannot evade a deny.
+
+## Tuning for the run mode
+
+**Interactive director session (default).** `ask` is fine — the human
+director is present and approves merges / destructive ops. Workers are
+still blocked from secret paths via `deny`.
+
+**Fully unattended director session.** Replace `ask` with `deny` for any
+publishing / destructive rule. The run will be evidence-only close-out
+when a human `ask` would have been required; that is the correct behavior
+(no watcher, no validated merge — per the universal skill).
+
+**Per-agent overrides.** pi-dynamic-workflows subagents can declare a
+narrower policy via the `agentType` mechanism in `@gotgenes/pi-subagents`
+or YAML frontmatter — see the pi-permission-system docs for the merge
+order.
+
+## What this does NOT cover
+
+- The `~/.pi/agent/extensions/pi-permission-system/config.json` (global)
+  config still applies if no project config exists; the project config
+  fully overrides it when present.
+- MCP-server behavior is not gated by this config — MCP tools are governed
+  by the `mcp` surface in the permission system and by the MCP server's
+  own auth. Keep `MEMROOS_AGENT_API_KEY` and similar secrets out of the
+  project tree entirely; they belong in `~/.memroos/agent-env` (mode 600,
+  owner-only directory) or 1Password.
+- loop-police is a separate package and runs independently of this config.

--- a/pi/references/requirements.md
+++ b/pi/references/requirements.md
@@ -1,0 +1,114 @@
+# Pi Package Requirements
+
+The `beastmode-pi` skill requires a pi installation with six companion
+packages. This document is the canonical list for new-host onboarding,
+CI checks, and drift audits.
+
+## Hard requirements
+
+| Requirement | Minimum | Why |
+|---|---|---|
+| `pi` (pi-coding-agent) | **≥ 0.80.6** | `@narumitw/pi-goal` registers an `agent_settled` lifecycle handler that was added in 0.80.6. Earlier versions will load the extension but the loop engine will silently never auto-continue. |
+| `node` | **≥ 20.x** | Pi package extensions are TypeScript ESM; modern pi releases depend on Node 20+ APIs. |
+| `npm` | **≥ 10.x** | Required by `pi install` for package resolution and the user-level install path (`~/.pi/agent/npm/`). |
+| Operating system | Linux x86_64 / aarch64, macOS arm64 / x86_64, WSL2 | Tested targets. Other Unix-likes likely work but are not in the support matrix. |
+
+## Required packages
+
+All six are MIT-licensed (or near-MIT) and install from npm:
+
+```bash
+pi install npm:@narumitw/pi-goal \
+  npm:@quintinshaw/pi-dynamic-workflows \
+  npm:pi-loop-police \
+  npm:@gotgenes/pi-permission-system \
+  npm:@juicesharp/rpiv-todo \
+  npm:@llblab/pi-telegram
+```
+
+| Package | Role | Optional? | Notes |
+|---|---|---|---|
+| `@narumitw/pi-goal` | Loop engine — `/goal`, `goal_complete`, `goal_blocked` | **required** | Without this, the skill's auto-continuation step is inert. |
+| `@quintinshaw/pi-dynamic-workflows` | Fan-out + model routing + verifier primitives | **required** | Without this, only single-agent work is possible. |
+| `pi-loop-police` | Anti-spin circuit breaker | **required** | Unattended runs WILL spin eventually; this is the kill switch. |
+| `@gotgenes/pi-permission-system` | Worker-contract enforcer | **required** | Without a project-level config, worker contracts rely on prose alone. See `pi-permission-config.md`. |
+| `@juicesharp/rpiv-todo` | Live progress overlay (TUI) | recommended | Strongly recommended for visibility; not blocking. |
+| `@llblab/pi-telegram` | Remote supervision (phone) | optional | Requires one-time `/telegram-setup` with a bot token. If absent, skip telegram and continue. |
+
+## One-line install + verify
+
+```bash
+# Install
+pi install npm:@narumitw/pi-goal \
+  npm:@quintinshaw/pi-dynamic-workflows \
+  npm:pi-loop-police \
+  npm:@gotgenes/pi-permission-system \
+  npm:@juicesharp/rpiv-todo \
+  npm:@llblab/pi-telegram
+
+# Verify all six are present
+pi list | grep -E 'pi-goal|pi-dynamic-workflows|pi-loop-police|pi-permission-system|rpiv-todo|pi-telegram' | wc -l   # expect: 6
+
+# Verify the four required tools register when a session starts
+pi -p "Without calling any tools, list tool names that start with goal_ or relate to workflows. One per line." \
+  | grep -E '^goal_|^workflow'   # expect: goal_complete, goal_blocked, workflow, workflow_control
+```
+
+## Skill placement
+
+The `beastmode-pi` skill can live in any of three locations; pi discovers
+from all of them and project-local wins over global on name collision:
+
+| Location | Scope | Best for |
+|---|---|---|
+| `~/.agents/skills/beastmode-pi/SKILL.md` | global | one-shot install across every repo |
+| `<repo>/.agents/skills/beastmode-pi/SKILL.md` | project (requires trusted project) | repos that want to pin a version |
+| Shipped as a pi package | npm-installable | shared team installs via `pi install npm:@scope/beastmode-pi` |
+
+For the canonical lac5q/beastmode home, both a project copy and the
+`pi/SKILL.md` reference live in the repo; install via copy or as a pi
+package.
+
+## Permission-system config
+
+The worker contract from the universal `beastmode` skill requires a
+project-level permission config at
+`<repo>/.pi/extensions/pi-permission-system/config.json`. Without it,
+secrets are not gated and `git push` / `git commit` run unprompted.
+See `pi-permission-config.md` for the starter.
+
+## Compatibility notes
+
+- **pi-goal** uses session-scoped goal state — it does not persist goals
+  across pi sessions. For durable goals, pair with a goal store (MemRoOS
+  `/api/gsd/goal`, a plain file, or the consumer repo's overlay).
+- **pi-dynamic-workflows** writes workflow runs to the user-level session
+  directory (`~/.pi/agent/sessions/`). Quotas and disk usage scale with
+  the number of long-running workflows.
+- **pi-permission-system** follows most-restrictive-wins semantics; a
+  broad `allow` cannot override a narrow `deny` on the same surface.
+  Project config overrides global config; per-agent YAML frontmatter
+  overrides both.
+- **pi-loop-police** has no configuration; counters reset on
+  `/loop-police reset` if you want a manual clear mid-session.
+- **pi-telegram** requires a BotFather token and a one-time
+  `/telegram-setup` interaction. It is the only optional package.
+
+## Known constraints
+
+- All six packages rely on pi's extension lifecycle (registration on
+  session start, `agent_settled` for pi-goal, etc.). Some packages
+  (notably pi-goal) advertise a minimum pi version; always check
+  `pi --version` before upgrading or downgrading.
+- `pi install` writes to user settings (`~/.pi/agent/settings.json`) by
+  default. Use `-l` to write to project settings (`.pi/settings.json`)
+  instead — useful for shared/reproducible installs.
+- The skill does not provision lane credentials (Qwen, MiniMax API,
+  Droid). Those are host-level environment concerns and live in
+  `~/.memroos/agent-env` (mode 600) or 1Password, never in the skill.
+
+## Updating the list
+
+When adding a new pi package to the skill, update this file in the
+same PR so the requirements list and the skill frontmatter stay in
+sync.

--- a/scripts/install-beastmode-pi.sh
+++ b/scripts/install-beastmode-pi.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# install-beastmode-pi.sh — run on main-mac to bring it to parity with oracle-1.
+#
+# Self-contained: installs pi 0.80.x (the version pi-goal requires), the six
+# beastmode-pi companion packages, and drops the skill at the user-global
+# location so pi discovers it in every repo.
+#
+# Usage (from anywhere on main-mac):
+#   curl -fsSL https://raw.githubusercontent.com/lac5q/beastmode/feature/beastmode-pi/scripts/install-beastmode-pi.sh | bash
+# or locally:
+#   bash scripts/install-beastmode-pi.sh
+#
+# Idempotent: safe to re-run. Re-runs are no-ops once everything is in place.
+
+set -euo pipefail
+
+bold() { printf '\n\033[1m== %s ==\033[0m\n' "$*"; }
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$*"; }
+warn() { printf '  \033[33m!\033[0m %s\n' "$*"; }
+err()  { printf '  \033[31m✗\033[0m %s\n' "$*" >&2; }
+
+# 1. pi itself
+bold "Install pi 0.80.x (requires >=0.80.6 for pi-goal)"
+if command -v pi >/dev/null 2>&1; then
+  v="$(pi --version 2>/dev/null || echo 0)"
+  if [ "$v" != "$(printf '%s\n%s' "$v" 0.80.6 | sort -V | tail -n1)" ]; then
+    warn "pi $v is too old; upgrading to @earendil-works/pi-coding-agent@latest"
+    npm i -g @earendil-works/pi-coding-agent --force >/dev/null 2>&1
+    ok "pi upgraded"
+  else
+    ok "pi $v already satisfies >=0.80.6"
+  fi
+else
+  npm i -g @earendil-works/pi-coding-agent --force >/dev/null 2>&1
+  ok "pi installed: $(pi --version)"
+fi
+
+# 2. six companion packages
+bold "Install beastmode-pi companion packages"
+for p in \
+  npm:@narumitw/pi-goal \
+  npm:@quintinshaw/pi-dynamic-workflows \
+  npm:pi-loop-police \
+  npm:@gotgenes/pi-permission-system \
+  npm:@juicesharp/rpiv-todo \
+  npm:@llblab/pi-telegram; do
+  pi install "$p" >/dev/null 2>&1
+  ok "installed $p"
+done
+
+# 3. skill at user-global location
+bold "Install beastmode-pi skill"
+SKILL_DIR="${HOME}/.agents/skills/beastmode-pi"
+mkdir -p "$SKILL_DIR"
+
+# Pull from the lac5q/beastmode repo at the feature branch. Falls back to a
+# raw URL fetch if curl/wget can reach github.
+URL="https://raw.githubusercontent.com/lac5q/beastmode/feature/beastmode-pi/pi/SKILL.md"
+DEST="${SKILL_DIR}/SKILL.md"
+if command -v curl >/dev/null 2>&1; then
+  if curl -fsSL "$URL" -o "$DEST.tmp" 2>/dev/null; then
+    mv "$DEST.tmp" "$DEST"
+    ok "skill fetched from $URL"
+  else
+    warn "could not fetch skill from $URL; paste it manually into $DEST"
+    warn "  (the skill ships in lac5q/beastmode/pi/SKILL.md on the feature/beastmode-pi branch)"
+  fi
+elif command -v wget >/dev/null 2>&1; then
+  if wget -q "$URL" -O "$DEST.tmp" 2>/dev/null; then
+    mv "$DEST.tmp" "$DEST"
+    ok "skill fetched from $URL"
+  else
+    warn "could not fetch skill from $URL; paste it manually into $DEST"
+  fi
+else
+  warn "no curl/wget available; paste the skill manually into $DEST"
+fi
+
+# 4. verify
+bold "Verify"
+pi -p "Do you have a skill called beastmode-pi available? Reply SKILL-OK or MISSING." 2>&1 | tail -1 | grep -q 'SKILL-OK' \
+  && ok "skill discoverable" \
+  || warn "skill NOT discoverable — check $DEST"
+
+pi -p "Without calling any tools, list tool names starting with goal_ or workflow. One per line." 2>&1 | grep -cE '^(goal_|workflow)' \
+  | xargs -I{} bash -c '[ {} -ge 3 ] && echo "  ✓ registered tools: {}" || echo "  ! only {} tool(s) registered"'
+
+bold "Done. Try:"
+echo "  pi --skill ~/.agents/skills/beastmode-pi/SKILL.md"
+echo "  # or just start pi in any repo — skill auto-discovers"

--- a/scripts/install-beastmode-pi.sh
+++ b/scripts/install-beastmode-pi.sh
@@ -6,7 +6,7 @@
 # location so pi discovers it in every repo.
 #
 # Usage (from anywhere on main-mac):
-#   curl -fsSL https://raw.githubusercontent.com/lac5q/beastmode/feature/beastmode-pi/scripts/install-beastmode-pi.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/lac5q/beastmode/main/scripts/install-beastmode-pi.sh | bash
 # or locally:
 #   bash scripts/install-beastmode-pi.sh
 #
@@ -53,9 +53,10 @@ bold "Install beastmode-pi skill"
 SKILL_DIR="${HOME}/.agents/skills/beastmode-pi"
 mkdir -p "$SKILL_DIR"
 
-# Pull from the lac5q/beastmode repo at the feature branch. Falls back to a
-# raw URL fetch if curl/wget can reach github.
-URL="https://raw.githubusercontent.com/lac5q/beastmode/feature/beastmode-pi/pi/SKILL.md"
+# Pull from the lac5q/beastmode repo on main (override with BEASTMODE_PI_REF).
+# Falls back to a raw URL fetch if curl/wget can reach github.
+REF="${BEASTMODE_PI_REF:-main}"
+URL="https://raw.githubusercontent.com/lac5q/beastmode/${REF}/pi/SKILL.md"
 DEST="${SKILL_DIR}/SKILL.md"
 if command -v curl >/dev/null 2>&1; then
   if curl -fsSL "$URL" -o "$DEST.tmp" 2>/dev/null; then
@@ -63,7 +64,7 @@ if command -v curl >/dev/null 2>&1; then
     ok "skill fetched from $URL"
   else
     warn "could not fetch skill from $URL; paste it manually into $DEST"
-    warn "  (the skill ships in lac5q/beastmode/pi/SKILL.md on the feature/beastmode-pi branch)"
+    warn "  (the skill ships in lac5q/beastmode/pi/SKILL.md on the ${REF} branch)"
   fi
 elif command -v wget >/dev/null 2>&1; then
   if wget -q "$URL" -O "$DEST.tmp" 2>/dev/null; then

--- a/scripts/install-beastmode-pi.sh
+++ b/scripts/install-beastmode-pi.sh
@@ -82,8 +82,12 @@ pi -p "Do you have a skill called beastmode-pi available? Reply SKILL-OK or MISS
   && ok "skill discoverable" \
   || warn "skill NOT discoverable — check $DEST"
 
-pi -p "Without calling any tools, list tool names starting with goal_ or workflow. One per line." 2>&1 | grep -cE '^(goal_|workflow)' \
-  | xargs -I{} bash -c '[ {} -ge 3 ] && echo "  ✓ registered tools: {}" || echo "  ! only {} tool(s) registered"'
+pi -p "Without calling any tools, list tool names starting with goal_ or workflow. One per line." 2>&1 | grep -cE '^(goal_|workflow)' | {
+  read -r n
+  if [ "$n" -ge 3 ]; then ok "registered tools: $n"
+  else warn "only $n tool(s) registered (expected >= 3)"
+  fi
+}
 
 bold "Done. Try:"
 echo "  pi --skill ~/.agents/skills/beastmode-pi/SKILL.md"


### PR DESCRIPTION
Adds the pi-specific harness adapter for the universal Beastmode v2.1 MofA orchestration framework, plus a one-line host installer and the package-requirements doc.

## What this PR adds

- **`pi/SKILL.md`** — the `beastmode-pi` skill. Pi-specific implementation of the universal Beastmode v2.1 pattern. Composes six installed pi packages into the loop + guardrail stack and defers all framework / strategy decisions to the universal `beastmode` skill. Hard rules, completion contract, and universal worker-contract enforcement are inherited.
- **`pi/references/pi-permission-config.md`** — starter `@gotgenes/pi-permission-system` project config that encodes the universal worker contract: secrets deny, `git push` / `git commit` / `rm -rf` / `sudo` / publish-class commands force `ask`, `external_directory` ask.
- **`pi/references/requirements.md`** — hard requirements (pi ≥ 0.80.6, node ≥ 20, npm ≥ 10), package table with required/optional flags, one-line install + verify, skill placement options, compatibility notes, known constraints.
- **`scripts/install-beastmode-pi.sh`** — self-contained, idempotent one-line installer for new hosts (main-mac, oracle-1, maeve-u1). Installs pi 0.80.x, the six companion packages, drops the skill at the user-global location, runs discovery + tool-registration smoke checks. The branch ref is overridable via `BEASTMODE_PI_REF` for reproducible installs from a tag.
- **`.gitignore`** — ignores `.pi/`, `.agents/skills/`, OS / editor noise.

## Why pi-goal specifically requires pi ≥ 0.80.6

`@narumitw/pi-goal` registers an `agent_settled` lifecycle handler that was added in pi 0.80.6. Earlier versions load the extension but the loop engine silently never auto-continues. The installer enforces this check.

## Verified

- maeve-u1, oracle-1, main-mac all at parity (pi 0.80.10 / 0.80.10 / 0.80.7 + 6 packages + skill + 4 tools registered)
- Smoke checks: `SKILL-OK` on discovery, 4 tools (goal_complete / goal_blocked / workflow / workflow_control) register
- Permission deny verified: `[pi-permission-system] Current agent is not permitted to access path 'canary.key' via tool 'read'.`
- Install script proven idempotent on oracle-1 (re-run = no-op, all green)