### PR TITLE
feat: add Terra/Sol Beastmode routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ See `references/autonomy-levels.md` for the full table and pi-flag mapping.
    ```bash
    bm "<goal>"                                          # prints rough phase ETA, then runs locally
    bm "<goal>" --gsd --frontier kimi3 --economy minimax # pick tiers, force GSD gating
+   bm "<validation goal>" --frontier sol --thinking medium # OAuth-backed Sol validator
    bm "<goal>" --on maeve-u1                            # dispatch to a fleet node
    bm "<goal>" --autonomy low|medium|high               # change how much surfaces
    scripts/phase-estimate "<goal>"                      # print the ETA without starting a run

--- a/references/tier-aliases.md
+++ b/references/tier-aliases.md
@@ -1,7 +1,7 @@
 # Tier Aliases
 
-Resolve friendly tier names (`kimi3`, `fable`, `opus`, `minimax`, `gpt5.5`,
-`qwen`) to concrete provider/model IDs. Read by `scripts/bm` before any
+Resolve friendly tier names (`kimi3`, `fable`, `opus`, `sol`, `terra`,
+`minimax`, `gpt5.5`, `qwen`) to concrete provider/model IDs. Read by `scripts/bm` before any
 `pi` invocation. Project-local override: `<repo>/.beastmode/tier-aliases.json`.
 
 ## Resolution order
@@ -23,6 +23,8 @@ Resolve friendly tier names (`kimi3`, `fable`, `opus`, `minimax`, `gpt5.5`,
 | `sonnet` | `anthropic` | `claude-sonnet-4-6` | frontier | Cheaper frontier option for tight budgets. |
 | `gpt5.5` | `openai-codex` | `gpt-5.5` | frontier | Default Codex-tier frontier. |
 | `gpt5.6` | `openai-codex` | `gpt-5.6-luna` | frontier | Latest Codex frontier (luna profile). |
+| `sol` | `openai-codex` | `gpt-5.6-sol` | frontier | Validator profile; use `--thinking medium`. |
+| `terra` | `openai-codex` | `gpt-5.6-terra` | frontier | Lead profile; use `--thinking high`. |
 | `minimax` | `minimax` | `MiniMax-M3` | economy | Default cheap execution tier. 1M ctx. |
 | `minimax-fast` | `minimax` | `MiniMax-M2.7-highspeed` | economy | Lower latency, smaller ctx. |
 | `qwen` | `qwen` | `qwen3.7-plus` | economy | Use when you need a second opinion from a different family. |
@@ -53,6 +55,10 @@ add a row to one, add it to the other in the same PR.
 2. Invokes: `pi --model kimi-coding/k3 --models kimi-coding/k3,minimax/MiniMax-M3 ...`.
 3. Unresolved alias → passes through unchanged so the user sees the real
    `pi` error and can fix the alias instead of silently mapping wrong.
+
+Reasoning effort is independent of the model alias. For the Terra lead and
+Sol validator split, run the lead through Hermes as Terra/high, then run the
+validation goal with `bm "<validation goal>" --frontier sol --thinking medium`.
 
 ## How to verify on a new host
 

--- a/scripts/bm
+++ b/scripts/bm
@@ -5,7 +5,7 @@
 #   bm "<goal>"                              # default: local, medium autonomy, auto models
 #   bm "<goal>" --gsd                        # force GSD phase gating
 #   bm "<goal>" --on maeve-u1                # dispatch to remote machine
-#   bm "<goal>" --frontier kimi3 --economy minimax
+#   bm "<goal>" --frontier sol --thinking medium
 #   bm "<goal>" --autonomy low|medium|high   # default medium
 #
 # The goal can appear anywhere on the command line; flags are parsed first
@@ -24,6 +24,7 @@ ON="auto"
 FRONTIER=""
 ECONOMY=""
 AUTONOMY="medium"
+THINKING="high"
 GOAL_PARTS=()
 PRINT_HELP=0
 
@@ -79,6 +80,8 @@ while [ $# -gt 0 ]; do
     --economy=*)       ECONOMY="${1#*=}"; shift ;;
     --autonomy)        AUTONOMY="${2:-medium}"; shift 2 ;;
     --autonomy=*)      AUTONOMY="${1#*=}"; shift ;;
+    --thinking)        THINKING="${2:-high}"; shift 2 ;;
+    --thinking=*)      THINKING="${1#*=}"; shift ;;
     -h|--help)         PRINT_HELP=1; shift ;;
     --)                shift; while [ $# -gt 0 ]; do GOAL_PARTS+=("$1"); shift; done ;;
     -*)                echo "bm: unknown arg: $1" >&2; usage ;;
@@ -93,6 +96,11 @@ fi
 case "$AUTONOMY" in
   low|medium|high) ;;
   *) echo "bm: --autonomy must be low|medium|high (got: $AUTONOMY)" >&2; exit 2 ;;
+esac
+
+case "$THINKING" in
+  none|minimal|low|medium|high|xhigh) ;;
+  *) echo "bm: --thinking must be none|minimal|low|medium|high|xhigh (got: $THINKING)" >&2; exit 2 ;;
 esac
 
 GOAL="${GOAL_PARTS[*]:-}"
@@ -116,7 +124,7 @@ PHASE_PROMPT="At the end of every phase, report phase name/status; model(s) used
 MODEL_FAILURE_PROMPT="On a model failure, report phase, provider/model, error, tokens, and attempted work. Stop and return control. Do not retry or switch models."
 [ "$AUTONOMY" = "high" ] && MODEL_FAILURE_PROMPT="On a model failure, report phase, provider/model, error, tokens, and attempted work. Find one safe workaround: narrow the task, retry once, or use an approved tier model. Validate it. If it fails, stop with goal_blocked evidence."
 [ "$GSD" = "1" ] && PHASE_PROMPT="Use GSD phase gating: gsd-plan-phase, gsd-execute-phase, gsd-verify-work, gsd-ship. $PHASE_PROMPT"
-PI_ARGS=(--skill ~/.agents/skills/beastmode-pi/SKILL.md --print --no-session --thinking high --append-system-prompt "$PHASE_PROMPT $MODEL_FAILURE_PROMPT")
+PI_ARGS=(--skill ~/.agents/skills/beastmode-pi/SKILL.md --print --no-session --thinking "$THINKING" --append-system-prompt "$PHASE_PROMPT $MODEL_FAILURE_PROMPT")
 [ -n "$FRONTIER" ]     && PI_ARGS+=(--model "$FRONTIER")
 [ -n "$ECONOMY" ]      && PI_ARGS+=(--models "$FRONTIER,$ECONOMY")
 [ "$AUTONOMY" = "low" ]  && PI_ARGS+=(--approve)
@@ -134,6 +142,7 @@ if [ "$ON" != "local" ]; then
   [ -n "$FRONTIER" ]     && REMOTE_FLAGS="$REMOTE_FLAGS --frontier $FRONTIER"
   [ -n "$ECONOMY" ]      && REMOTE_FLAGS="$REMOTE_FLAGS --economy $ECONOMY"
   REMOTE_FLAGS="$REMOTE_FLAGS --autonomy $AUTONOMY"
+  REMOTE_FLAGS="$REMOTE_FLAGS --thinking $THINKING"
   # shellcheck disable=SC2086
   exec ssh "$ON" "bm '$GOAL' $REMOTE_FLAGS"
 fi

--- a/scripts/tier-aliases.json
+++ b/scripts/tier-aliases.json
@@ -9,6 +9,8 @@
   "sonnet":       { "provider": "anthropic",   "model": "claude-sonnet-4-6",  "tier": "frontier" },
   "gpt5.5":       { "provider": "openai-codex", "model": "gpt-5.5",           "tier": "frontier" },
   "gpt5.6":       { "provider": "openai-codex", "model": "gpt-5.6-luna",      "tier": "frontier" },
+  "sol":          { "provider": "openai-codex", "model": "gpt-5.6-sol",       "tier": "frontier" },
+  "terra":        { "provider": "openai-codex", "model": "gpt-5.6-terra",     "tier": "frontier" },
   "minimax":      { "provider": "minimax",     "model": "MiniMax-M3",         "tier": "economy"  },
   "minimax-fast": { "provider": "minimax",     "model": "MiniMax-M2.7-highspeed", "tier": "economy" },
   "qwen":         { "provider": "qwen",        "model": "qwen3.7-plus",       "tier": "economy"  },

--- a/tests/test-bm-thinking.sh
+++ b/tests/test-bm-thinking.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/pi" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$BM_TEST_ARGS"
+EOF
+chmod +x "$TMP/bin/pi"
+
+BM_TEST_ARGS="$TMP/args" PATH="$TMP/bin:$PATH" \
+  "$ROOT/scripts/bm" "validate the diff" --frontier sol --thinking medium
+
+python3 - "$TMP/args" <<'PY'
+from pathlib import Path
+import sys
+args = Path(sys.argv[1]).read_text().splitlines()
+
+def value(flag):
+    return args[args.index(flag) + 1]
+
+assert value("--model") == "openai-codex/gpt-5.6-sol", args
+assert value("--thinking") == "medium", args
+PY


### PR DESCRIPTION
## Summary
- add `terra` and `sol` OAuth model aliases
- add `--thinking` so Sol validators can run at medium effort
- preserve reasoning effort through remote dispatch

## Validation
- `bash -n scripts/bm`
- `tests/test-bm-thinking.sh`
- live OAuth smoke: `bm ... --frontier sol --thinking medium`
- Sol-medium Beastmode validator: PASS