### PR TITLE
Per-phase usage reports, model-drift surfacing, blocking gates below high autonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See `references/model-routing.md` for the per-phase routing table and escalation
 
 ## Autonomy Levels
 
-Beastmode runs with one of three autonomy levels — how much the orchestrator decides on its own before surfacing to a human. **Default: medium.**
+Beastmode runs with one of three autonomy levels — how much the orchestrator decides on its own before surfacing to a human. **Default: medium.** Below `high`, surfaced gates are **blocking** — the run posts its per-phase usage report (requested vs actual models, tokens vs budget, time vs estimate) and stops for approval; only `high` rolls through gates on its own. **Model drift** (a task served by a model other than the one requested) surfaces at every level.
 
 | Level | Surfaces to you | Best for |
 |---|---|---|

--- a/SKILL.md
+++ b/SKILL.md
@@ -102,6 +102,9 @@ Use beastmode for complex tasks that need:
 3. **Every phase has an acceptance contract.** Define goal, non-goals, verification commands, and escalation triggers before delegation.
 4. **Every phase improves the loop.** Record learnings, errors, routing mistakes, and token/cost surprises. Promote repeated lessons into skills/config.
 5. **Escalation doesn't skip self-improvement.** Record why the cheap route failed and whether routing rules should change.
+6. **Usage is reported per phase, not just at the end.** Every phase closes with a usage report: requested vs actual model per task, tokens used vs phase budget, actual vs estimated time (see `references/autonomy-levels.md` for the format). If the harness doesn't expose a value, say "unavailable" — never omit the report.
+7. **Model drift always surfaces.** If a task was served by a model other than the requested `provider/model` (router fallback, harness default, silent substitution), flag it as MODEL DRIFT in the phase report immediately, at every autonomy level. Drifted work is not `validated` until re-validated under the correct tier.
+8. **Gates are blocking below high autonomy.** At `low` and `medium` autonomy (medium is the default), the run stops at each phase gate — report, then wait for approval before the next phase or any merge. Only `--autonomy high` proceeds through gates automatically, and even it halts on its always-surface events.
 
 ## Choosing Your Harness
 
@@ -513,7 +516,7 @@ See `references/context-rot-mitigation.md` for full details on architectural fix
 
 - **Model routing:** See `references/model-routing.md` for the per-phase tier routing table, provider configuration examples (Fable, Kimi 3, MiniMax M3), the mechanical-vs-judgment validation split, and the escalation ladder.
 - **Tier aliases:** See `references/tier-aliases.md` (and `tier-aliases.json`) for the friendly-name → `provider/model` map consumed by `scripts/bm`. Verified against `pi --list-models` on oracle-1 / maeve-u1.
-- **Autonomy levels:** See `references/autonomy-levels.md` for `low` / `medium` (default) / `high` autonomy — what surfaces, what runs silent, and how to map them to `pi --approve` / `--no-builtin-tools`.
+- **Autonomy levels:** See `references/autonomy-levels.md` for `low` / `medium` (default) / `high` autonomy — what surfaces, what runs silent, blocking-gate semantics below high, the per-phase usage report format, model-drift detection, and how to map levels to `pi --approve` / `--no-builtin-tools`.
 - **Context rot mitigation:** See `references/context-rot-mitigation.md` for detailed analysis of context accumulation, architectural fixes, and monitoring strategies.
 - **Orchestration comparison:** See `references/orchestration-comparison.md` for the evolution from early prototypes to v2.0.
 - **Public sharing checklist:** See `references/public-sharing-checklist.md` for sanitization guidelines when publishing beastmode skills publicly.

--- a/references/autonomy-levels.md
+++ b/references/autonomy-levels.md
@@ -13,6 +13,43 @@ committing/pushing, no secrets, verifier-first, no watcher = no validated).
 **Default: medium.** Most feature work, most reviews, no chat spam — only the
 high-risk gates escalate. Switch with `bm "<goal>" --autonomy low|high`.
 
+## Surfacing is blocking below high
+
+At **low** and **medium**, "surfaces" means **stops**: the run emits its phase
+report, then halts and waits for human approval before the next phase or any
+merge. It never continues past a surfaced gate on its own. Only **high**
+proceeds through gates automatically (and even then it halts on its
+always-surface events above). If a run at low/medium keeps going after a gate,
+that is a harness bug — treat it as a `goal_blocked` and stop it.
+
+## Per-phase usage reports (all levels)
+
+Every phase ends with a usage report, at every autonomy level — this is how
+you see cost as it accrues instead of at the end:
+
+```
+Phase <n> <name>: <status>
+Models: requested <tier: provider/model> → actual <provider/model per task>
+Tokens: <used> / <phase budget> (<percent>)  Time: <actual> vs <estimate>
+Drift: none | MODEL DRIFT: <requested> → <actual> on <task(s)>
+```
+
+At low/medium the report is the gate — approval resumes the run. At high the
+reports accumulate into the final output in order.
+
+## Model drift always surfaces
+
+**MODEL DRIFT** = a task was served by a model other than the requested
+`provider/model` — router fallback, harness default, or silent substitution.
+Detect it by comparing the worker `meta.json` `model` field (or harness
+journal) against the resolved tier alias. Drift surfaces at **every** level,
+including high, because it breaks two guarantees at once: cost (a frontier
+substitute burns budget) and trust (an economy substitute on design-tier work
+skips the judgment the gate assumed). Drifted work is not `validated` until
+re-validated under the correct tier. Record every drift in the learning entry
+— repeated drift on the same alias means the tier alias or provider config is
+wrong.
+
 ## Mapping to pi flags
 
 | Level | pi flag | What you give up |

--- a/scripts/bm
+++ b/scripts/bm
@@ -158,11 +158,14 @@ if [ "$ON" = "local" ] && [ "${BM_SKIP_MODEL_CHECK:-0}" != "1" ]; then
 fi
 
 # Build pi arguments once (used in local run).
-PHASE_PROMPT="At the end of every phase, report phase name/status; model(s) used; tokens used / phase budget and percent; actual versus estimated time. Use the workflow journal or budget output. Say unavailable when a harness does not expose a value."
-MODEL_FAILURE_PROMPT="On a model failure, report phase, provider/model, error, tokens, and attempted work. Stop and return control. Do not retry or switch models."
-[ "$AUTONOMY" = "high" ] && MODEL_FAILURE_PROMPT="On a model failure, report phase, provider/model, error, tokens, and attempted work. Find one safe workaround: narrow the task, retry once, or use an approved tier model. Validate it. If it fails, stop with goal_blocked evidence."
+PHASE_PROMPT="At the end of every phase, report phase name/status; requested model versus the model that actually served each task (from worker meta.json or the harness journal); tokens used / phase budget and percent; actual versus estimated time. Use the workflow journal or budget output. Say unavailable when a harness does not expose a value. If any task was served by a model other than the requested provider/model (router fallback, harness default, silent substitution), flag it as MODEL DRIFT in the phase report immediately with requested and actual IDs — never fold drift into a footnote."
+MODEL_FAILURE_PROMPT="On a model failure or MODEL DRIFT, report phase, provider/model (requested and actual), error, tokens, and attempted work. Stop and return control. Do not retry or switch models."
+[ "$AUTONOMY" = "high" ] && MODEL_FAILURE_PROMPT="On a model failure, report phase, provider/model, error, tokens, and attempted work. Find one safe workaround: narrow the task, retry once, or use an approved tier model. Validate it. If it fails, stop with goal_blocked evidence. MODEL DRIFT always surfaces in the phase report even at high autonomy; drifted work must be re-validated before merge."
+# Below high autonomy, phase gates are blocking: report, then stop and wait.
+GATE_PROMPT="After each phase report, STOP and return control for approval before starting the next phase or merging. Do not continue past a gate on your own."
+[ "$AUTONOMY" = "high" ] && GATE_PROMPT="Proceed through phase gates without stopping, but include every phase report in the final output in order."
 [ "$GSD" = "1" ] && PHASE_PROMPT="Use GSD phase gating: gsd-plan-phase, gsd-execute-phase, gsd-verify-work, gsd-ship. $PHASE_PROMPT"
-PI_ARGS=(--skill ~/.agents/skills/beastmode-pi/SKILL.md --print --no-session --thinking "$THINKING" --append-system-prompt "$PHASE_PROMPT $MODEL_FAILURE_PROMPT")
+PI_ARGS=(--skill ~/.agents/skills/beastmode-pi/SKILL.md --print --no-session --thinking "$THINKING" --append-system-prompt "$PHASE_PROMPT $MODEL_FAILURE_PROMPT $GATE_PROMPT")
 [ -n "$FRONTIER" ]     && PI_ARGS+=(--model "$FRONTIER")
 [ -n "$ECONOMY" ]      && PI_ARGS+=(--models "$FRONTIER,$ECONOMY")
 [ "$AUTONOMY" = "low" ]  && PI_ARGS+=(--approve)


### PR DESCRIPTION
## Summary

Three run-visibility/safety guarantees, requested by Luis:

1. **Usage is reported along the way.** Every phase closes with a usage report (requested vs actual model per task, tokens used vs phase budget with percent, actual vs estimated time). Format documented in `references/autonomy-levels.md`; enforced as SKILL.md hard rule 6 and in the `bm` phase prompt.
2. **Requested-model mismatches are reported.** New MODEL DRIFT concept: if a task was served by a model other than the requested `provider/model` (router fallback, harness default, silent substitution — detected via worker `meta.json` `model` vs the resolved tier alias), it's flagged immediately in the phase report at **every** autonomy level, and drifted work isn't `validated` until re-validated under the correct tier. Complements the existing start-time preflight (which only catches models missing from the host) and the model-*failure* prompt (which only catches errors, not silent substitution).
3. **The run stops when autonomy isn't high.** Gates below `high` are now explicitly *blocking*: at `low`/`medium` (default) the run posts its phase report, halts, and waits for approval before the next phase or any merge. `bm` adds a gate prompt implementing this; `--autonomy high` rolls through gates but still halts on its always-surface events.

### Files

- `scripts/bm` — drift check in PHASE_PROMPT, drift added to MODEL_FAILURE_PROMPT, new GATE_PROMPT keyed off `$AUTONOMY`
- `references/autonomy-levels.md` — "Surfacing is blocking below high", per-phase usage report format, "Model drift always surfaces"
- `SKILL.md` — hard rules 6–8
- `README.md` — autonomy section notes blocking gates + drift

### Testing

`bash -n scripts/bm` clean; `tests/test-bm-model-check.sh` (6/6) and `tests/test-bm-thinking.sh` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EUdPJEANuMqoP1wJcdZsE

---
_Generated by [Claude Code](https://claude.ai/code/session_012EUdPJEANuMqoP1wJcdZsE)_