### PR TITLE
fix: make the ACN provenance gate fail closed (v2.3.0)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: tests
+
+# Beastmode's whole premise is that nothing is validated until a gate says so.
+# Running that gate on every push is the least the repo can do for itself.
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run the beastmode gate
+        run: ./tests/run-all.sh
+
+      - name: Working tree must be unchanged by the tests
+        run: |
+          # A test run that edits the repo hides regressions in its own
+          # fixtures. tests/test-acn-parity.sh used to rewrite them on
+          # every run; this check keeps that from coming back.
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "tests modified the working tree:"
+            git status --porcelain
+            git diff
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ Thumbs.db
 # Node — only if a pi package build step is added later
 node_modules/
 *.log
+
+# Python bytecode from the stdlib helpers in scripts/
+__pycache__/
+*.pyc

--- a/.learnings/BEASTMODE.md
+++ b/.learnings/BEASTMODE.md
@@ -22,10 +22,15 @@
 
 - **`bm` defects found while tracing seat resolution:** `--models "$FRONTIER,$ECONOMY"` emitted a leading comma when `--economy` was passed without `--frontier`; the `--on` remote dispatch spliced the raw goal into `bm '$GOAL' ...`, so a goal containing an apostrophe ended the quote and the remainder ran as remote shell words; and `--harness claude` handed the resolved `provider/model` to `claude --model`, which wants a bare model id (`enforce-models` even warned about it on every correct invocation).
 
+- **The first fix reintroduced the same bug one level up — caught by the repo's automated reviewer, not by me.** Candidate detection keyed on provenance fields (`requested_model`, `actual_model`, `stop_reason`, …), so a child that died *before* writing any of them was not recognised as a child at all: it vanished from the report entirely and a valid sibling carried the batch to exit 0. Reproduced — a directory holding one good meta plus `{"id":"lost","usage":{...}}` printed `Drift: none`, exit 0, with `lost` appearing nowhere. *The lesson:* recognition must key on "is this a child record" and never on "did this child prove something". The moment those two questions share a predicate, failing to prove something makes you invisible rather than failing. Detection and judgment have to be separate functions — they now are (`is_child_record` vs `Row._classify`).
+- **Scanning can only judge what exists.** Even with detection fixed, a worker killed before writing any file leaves nothing to find, and one surviving sibling still passed the batch. Closed with `--expect`, which reads the batch's `tasks[].id` — a manifest `schema/acn-contract.json` already required, so nothing new had to be invented to make absence detectable.
+
 ## Routing rule to change
 
 - **None.** Verification-cost routing held up.
 - **Add, as a contract rule rather than a routing rule:** *a gate must have a verdict for "cannot determine", and that verdict must fail.* Every fail-open here was a two-valued gate (drift / no-drift) meeting a three-valued reality (drift / no-drift / unprovable), and "unprovable" fell into the pass bucket by default. Now `ok` / `drift` / `unverifiable`, with `--allow-empty` as the explicit assertion when a batch legitimately had no children.
+- **Add:** *a gate over a set fails if any member fails; no member's pass may substitute for another's.* Both rounds of this bug had that shape — an unprovable child disappearing into a batch a valid sibling then carried. Aggregate verdicts hide precisely the members that failed hardest.
+- **Add, on review routing:** the adversarial reviewer earned its seat here. A cross-family automated review caught a fail-open in the very change that existed to remove fail-opens, on a diff that had 19 passing checks and green CI. "Tests green" is not "reviewed", and self-review by the author of the fix is the weakest link in the chain.
 
 ## Skill/config updates needed
 

--- a/.learnings/BEASTMODE.md
+++ b/.learnings/BEASTMODE.md
@@ -1,3 +1,46 @@
+# Beastmode learnings
+
+## BM-20260726-2300 architecture review (v2.3.0)
+
+- Reviewer: claude-opus-5, single session, no fan-out (review scope, not an ACN run).
+- Harness: claude-code, direct.
+- Acceptance checks: `./tests/run-all.sh` — 6/6 steps green, ACN parity 19 PASS / 0 FAIL / 1 SKIP (pi not on host). Every new check negative-tested by deliberately breaking the invariant and confirming a FAIL.
+- Result: PASS.
+
+## What failed / drifted
+
+- **The drift gate failed open in two ways, and both were reachable from the repo's own docs.** `enforce-models --check-meta` skipped any meta lacking `requested_model`/`actual_model` as "not a meta file we recognise", and `acn-report` rendered the same meta as `requested: unavailable → actual: unavailable`, i.e. equal, i.e. `Drift: none`. Meanwhile `references/autonomy-levels.md` and `pi/SKILL.md` both instructed workers to emit `{"id","model","stop_reason","usage"}` — the one shape neither tool could evaluate. A pi worker following the documented contract passed the gate while proving nothing. An empty run directory also exited 0.
+  *Routing rule to change?* No. The rule ("no watcher, no validated"; "if the runtime cannot prove the child's model, the child is an unverified draft lane") was already correct and already written down — in `adapters/codex/SKILL.md`, which was the only surface that named the unverifiable case. The tooling just never implemented it. **The lesson is about where rules live:** a hard rule stated in prose in one adapter is not enforced anywhere. It has to be a verdict the gate can return.
+
+- **One contract, two implementations.** `enforce-models --check-meta` and `acn-report` each walked the meta directory with different glob rules (`**/*.json` vs `*.json` + `**/meta.json`) and compared fields differently. Nothing asserted they agreed, so a child could pass one tool and fail the other. Collapsed onto `scripts/lib/acn_meta.py`; parity check (e3) now asserts identical exit codes across every fixture.
+
+- **`schema/` was decorative.** Called "the machine source of truth" in four documents, but no code read it — `meta_json_required_fields`, `batch_required_fields`, and `task_required_fields` were declared and then ignored, while the tools hard-coded their own field expectations. The gate now reads the schema; check (e4) asserts the prose block in `references/acn-contract.md` and the schema list are the same set.
+
+- **Tests rewrote their own fixtures.** `test-acn-parity.sh` regenerated `tests/fixtures/acn-meta/*` on every run, so the committed copies were decorative too and had already drifted from the schema (missing `stop_reason`, `files_changed`, `commands_run`, `verify`). Fixtures are now read, not written; CI asserts the suite leaves the tree clean.
+
+- **No entrypoint, no CI.** Three test scripts, no way to run them together, nothing running them automatically. A repo whose thesis is "nothing is validated until a gate says so" had no gate on itself. Added `tests/run-all.sh` + `.github/workflows/tests.yml`.
+
+- **`bm` defects found while tracing seat resolution:** `--models "$FRONTIER,$ECONOMY"` emitted a leading comma when `--economy` was passed without `--frontier`; the `--on` remote dispatch spliced the raw goal into `bm '$GOAL' ...`, so a goal containing an apostrophe ended the quote and the remainder ran as remote shell words; and `--harness claude` handed the resolved `provider/model` to `claude --model`, which wants a bare model id (`enforce-models` even warned about it on every correct invocation).
+
+## Routing rule to change
+
+- **None.** Verification-cost routing held up.
+- **Add, as a contract rule rather than a routing rule:** *a gate must have a verdict for "cannot determine", and that verdict must fail.* Every fail-open here was a two-valued gate (drift / no-drift) meeting a three-valued reality (drift / no-drift / unprovable), and "unprovable" fell into the pass bucket by default. Now `ok` / `drift` / `unverifiable`, with `--allow-empty` as the explicit assertion when a batch legitimately had no children.
+
+## Skill/config updates needed
+
+- The `opus5` alias in `scripts/tier-aliases.json` resolves to `claude-opus-4-8` and `sonnet` to `claude-sonnet-4-6`. Left alone — the file states it was verified against `pi --list-models` on oracle-1 / maeve-u1, so those may be what those hosts actually serve. Worth re-checking: if newer Opus/Sonnet are available, the alias names are misleading as written.
+- `bm`'s documented exit-code contract ("0 = goal_complete, 1 = goal_blocked") is not implemented — `bm` `exec`s the harness, so callers get the harness's exit code with no mapping. Either implement the mapping or drop the claim from the header.
+- Autonomy → harness flag mapping is only symmetric at `high`. `low` maps to `--approve` on pi and to nothing on hermes/claude/codex, so "autonomy semantics are identical across harnesses by construction" currently holds for the prompt strings only, not the enforcement flags.
+- `bm --watcher <alias>` resolves and preflights the watcher seat but never passes it to any harness — it reaches the run as prompt text only.
+
+## Promoted to
+
+- `schema/acn-contract.json` (v1.1): `unverifiable_policy`, `gate_verdicts`, `gate_implementation`, and a fifth hard rule.
+- `scripts/lib/acn_meta.py`: the rule as executable code rather than prose.
+
+---
+
 # Beastmode learnings — feat/acn-unification (v2.2.0 consolidation)
 
 ## BM-20260726-1200 feat/acn-unification consolidation

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ See `references/autonomy-levels.md` for the full table and pi-flag mapping.
    bm "<goal>" --autonomy low|medium|high               # change how much surfaces
    scripts/phase-estimate "<goal>"                      # print the ETA without starting a run
    scripts/enforce-models --harness pi --model kimi-coding/k3   # preflight a seat model
+   scripts/enforce-models --check-meta <run-dir>        # postflight gate: drift + unprovable provenance
    scripts/acn-report <dir-of-meta.json>                # phase usage report + MODEL DRIFT check
    ```
 
@@ -74,6 +75,8 @@ See `references/autonomy-levels.md` for the full table and pi-flag mapping.
 ## One Vocabulary (v2.2)
 
 Families, tiers, seats, autonomy levels, and the ACN fan-out contract are defined once in `schema/` (machine-readable) and rendered for humans in `references/families-tiers-seats.md`, `references/autonomy-levels.md`, `references/acn-contract.md`, and `references/tier-aliases.md`. Harness adapters (`adapters/hermes`, `pi/`, `adapters/claude-code`, `adapters/codex`) implement the same rules: pinned executor models, per-child `meta.json` (requested vs actual), MODEL DRIFT always surfaces and blocks `validated`, and gates are blocking below `high` autonomy.
+
+The provenance gate is fail-closed in both directions: a child whose model **differs** from the pinned one is `drift`, and a child whose model **cannot be established** — missing meta, unreadable meta, or a single merged `model` field instead of `requested_model` + `actual_model` — is `unverifiable`. Both block `validated`. One implementation (`scripts/lib/acn_meta.py`) backs both `enforce-models --check-meta` and `acn-report`, and it reads the required field list out of `schema/acn-contract.json` rather than hard-coding it.
 
 ## Files
 
@@ -93,9 +96,25 @@ Families, tiers, seats, autonomy levels, and the ACN fan-out contract are define
 - `scripts/bm` — Runner CLI for one-shot goals with harness/tier picks, phase reports, and `--on` dispatch
 - `scripts/enforce-models` — Model preflight/postflight (drift fail-closed) shared by all harnesses
 - `scripts/acn-report` — Normalize ACN child metas into the phase usage report
+- `scripts/lib/acn_meta.py` — The model-provenance gate itself (`ok` / `drift` / `unverifiable`), read by both of the above so they cannot disagree
 - `scripts/lib/prompts.sh` — Shared phase/gate/model-failure prompt builders used by `bm` and adapters
 - `scripts/phase-estimate` — Rough per-phase wall-clock estimate from the goal scope
 - `scripts/install-beastmode-pi.sh` — Idempotent bootstrap of `pi` + 6 companion packages
+- `tests/run-all.sh` — Every gate in one command (syntax, schema validity, ACN parity, `bm` preflight); what CI runs
+
+## Testing
+
+```bash
+./tests/run-all.sh      # syntax + JSON validity + ACN parity + bm preflight
+```
+
+Runs on every push via `.github/workflows/tests.yml`, which additionally
+asserts the suite leaves the working tree unmodified. The ACN parity test
+covers the invariants prose alone can't hold: the drift gate fails closed on
+unprovable provenance, `enforce-models` and `acn-report` return the same
+verdict for the same directory, `references/acn-contract.md` lists exactly the
+meta fields `schema/acn-contract.json` declares, and each adapter's canonical
+version cross-reference matches `SKILL.md`.
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ See `references/autonomy-levels.md` for the full table and pi-flag mapping.
    scripts/phase-estimate "<goal>"                      # print the ETA without starting a run
    scripts/enforce-models --harness pi --model kimi-coding/k3   # preflight a seat model
    scripts/enforce-models --check-meta <run-dir>        # postflight gate: drift + unprovable provenance
+   scripts/enforce-models --check-meta <run-dir> --expect <batch.json>  # also catch a child that wrote nothing
    scripts/acn-report <dir-of-meta.json>                # phase usage report + MODEL DRIFT check
    ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -8,7 +8,7 @@ description: >
   with a self-improving learning loop that promotes lessons back into skills.
   Harness-agnostic: works with Hermes ACN (async parallel sub-agents), Pi,
   Claude Code, Codex, Ultraswarm, GSD, delegate_task, or manual orchestration.
-version: 2.2.0
+version: 2.3.0
 author: Luis Calderon
 tags: [beastmode, orchestration, multi-agent, cost-optimization, model-routing, self-improving, worktrees]
 related_skills: [ultraswarm, gsd, subagent-driven-development, self-improvement]
@@ -106,7 +106,7 @@ Use beastmode for complex tasks that need:
 4. **Every phase improves the loop.** Record learnings, errors, routing mistakes, and token/cost surprises. Promote repeated lessons into skills/config.
 5. **Escalation doesn't skip self-improvement.** Record why the cheap route failed and whether routing rules should change.
 6. **Usage is reported per phase, not just at the end.** Every phase closes with a usage report: requested vs actual model per task, tokens used vs phase budget, actual vs estimated time (see `references/autonomy-levels.md` for the format). If the harness doesn't expose a value, say "unavailable" — never omit the report.
-7. **Model drift always surfaces.** If a task was served by a model other than the requested `provider/model` (router fallback, harness default, silent substitution), flag it as MODEL DRIFT in the phase report immediately, at every autonomy level. Drifted work is not `validated` until re-validated under the correct tier.
+7. **Model drift always surfaces, and so does not knowing.** If a task was served by a model other than the requested `provider/model` (router fallback, harness default, silent substitution), flag it as MODEL DRIFT in the phase report immediately, at every autonomy level. Drifted work is not `validated` until re-validated under the correct tier. A task whose serving model cannot be established at all is **unverifiable** and is treated the same way — never let a silent "unavailable" read as a pass.
 8. **Gates are blocking below high autonomy.** At `low` and `medium` autonomy (medium is the default), the run stops at each phase gate — report, then wait for approval before the next phase or any merge. Only `--autonomy high` proceeds through gates automatically, and even it halts on its always-surface events.
 
 ## The ACN Layer (Async Parallel Sub-agents)
@@ -127,7 +127,8 @@ The shared rules (all harnesses):
 3. **Parallel by default** for independent executor slices; group same-lane workers (prompt-cache warmth); default concurrency 3 unless the harness is explicitly configured higher.
 4. **Background where supported** — the director doesn't block the chat path waiting on workers (Hermes background batches, Codex background exec, Claude parallel sessions). Orchestrator children may wait to synthesize.
 5. **Consolidate → mechanical validation (economy) → watcher judgment (frontier) → gate by autonomy.**
-6. **MODEL DRIFT always surfaces** (requested vs actual per child, `meta.json` shape in `schema/acn-contract.json`) and blocks `validated` at every autonomy level. `scripts/acn-report` normalizes child metas into the phase report.
+6. **MODEL DRIFT always surfaces** (requested vs actual per child, `meta.json` shape in `schema/acn-contract.json`) and blocks `validated` at every autonomy level. `scripts/acn-report` normalizes child metas into the phase report; `scripts/enforce-models --check-meta <dir>` is the gate. Both run the same checker (`scripts/lib/acn_meta.py`), so they cannot disagree about whether a batch is validated.
+7. **Unprovable provenance fails closed.** A child whose `meta.json` is missing, unreadable, or reports a single merged `model` instead of `requested_model` + `actual_model` is **unverifiable** — the gate exits non-zero on it exactly as it does on drift. "We could not tell which model ran this" is not a pass. An ACN run that produced no child metas at all is likewise a failure unless you assert `--allow-empty`.
 
 ## Choosing Your Harness
 
@@ -139,7 +140,7 @@ For one-shot goals without writing a full plan: `bm "<goal>"` from any repo.
 Parses `--harness hermes|pi|claude|codex` (default `pi`), `--gsd`,
 `--frontier <alias>`, `--economy <alias>`, `--watcher <alias>`,
 `--on local|<host>`, `--autonomy low|medium|high` (default `medium`). Tier
-aliases resolve via `references/tier-aliases.json` — `kimi3` →
+aliases resolve via `scripts/tier-aliases.json` — `kimi3` →
 `kimi-coding/k3`, `fable` → `anthropic/claude-fable-5`, `minimax` →
 `minimax/MiniMax-M3`, `grok` → `xai-oauth/grok-4.5`, etc. Override per-repo
 with `<repo>/.beastmode/tier-aliases.json`. See `scripts/bm` and

--- a/adapters/claude-code/SKILL.md
+++ b/adapters/claude-code/SKILL.md
@@ -12,7 +12,7 @@ source_repo: https://github.com/lac5q/beastmode/blob/main/adapters/claude-code/S
 
 This skill is **only the harness mechanics**. The framework, tier-routing
 rule, verifier-first design principle, and self-improvement loop live in
-the canonical `beastmode` skill (v2.2.0) — load it first and follow it.
+the canonical `beastmode` skill (v2.3.0) — load it first and follow it.
 
 ## Only the harness mechanics
 
@@ -109,6 +109,13 @@ router fallback, harness default, or silent substitution. Drift surfaces
 at every autonomy level (including high) and blocks `validated` until
 the task is re-run under the pinned model.
 
+Unverifiable child model = **UNVERIFIED DRAFT** lane. A child whose meta is
+missing, unreadable, or carries a single merged `model` instead of both
+model fields cannot be compared, and an impossible comparison is not a
+pass. Output may be used as input but is never `validated` until re-checked
+under a pinned model. `scripts/enforce-models --check-meta <run-dir>` is the
+gate; exit 1 means drift or unverifiable.
+
 ## Operating loop
 
 1. Load the universal `beastmode` skill first. Read the acceptance
@@ -158,6 +165,6 @@ Universal Beastmode artifacts, written in this order:
 
 ## See also
 
-- `beastmode` (v2.2.0) — the canonical framework this adapter implements
+- `beastmode` (v2.3.0) — the canonical framework this adapter implements
 - `schema/acn-contract.json` — batch / task / meta.json shapes
 - `references/autonomy-levels.md` and `references/orchestration-comparison.md`

--- a/adapters/codex/SKILL.md
+++ b/adapters/codex/SKILL.md
@@ -12,7 +12,7 @@ source_repo: https://github.com/lac5q/beastmode/blob/main/adapters/codex/SKILL.m
 
 This skill is **only the harness mechanics**. The framework, tier-routing
 rule, verifier-first design principle, and self-improvement loop live in
-the canonical `beastmode` skill (v2.2.0) — load it first and follow it.
+the canonical `beastmode` skill (v2.3.0) — load it first and follow it.
 This adapter tells you which Codex primitives implement which seat and
 which external lanes the bounded workers can call.
 
@@ -116,6 +116,10 @@ under the pinned model.
 
 Unverifiable child model = **UNVERIFIED DRAFT** lane. Output may be used
 as input but is never `validated` until re-checked under a pinned model.
+A meta carrying a single merged `model` instead of both `requested_model`
+and `actual_model` is unverifiable — there is nothing to compare.
+`scripts/enforce-models --check-meta <run-dir>` is the gate; exit 1 means
+drift or unverifiable.
 
 ## Autonomy mapping
 
@@ -216,7 +220,7 @@ still referencing `beastmode-qwen-cloud` should migrate to this adapter.
 
 ## See also
 
-- `beastmode` (v2.2.0) — the canonical framework this adapter implements
+- `beastmode` (v2.3.0) — the canonical framework this adapter implements
 - `schema/acn-contract.json` — machine source of truth for batch / task
   / meta.json shapes
 - `references/autonomy-levels.md` and `references/orchestration-comparison.md`

--- a/adapters/hermes/SKILL.md
+++ b/adapters/hermes/SKILL.md
@@ -12,7 +12,7 @@ source_repo: https://github.com/lac5q/beastmode/blob/main/adapters/hermes/SKILL.
 
 This skill is **only the harness mechanics**. The framework, tier-routing
 rule, verifier-first design principle, and self-improvement loop live in the
-canonical `beastmode` skill (v2.2.0) - load it first and follow it. This
+canonical `beastmode` skill (v2.3.0) - load it first and follow it. This
 adapter tells you which Hermes primitives implement which seat and how to
 wire them together.
 
@@ -119,6 +119,19 @@ same task is re-run under the pinned model. Record every drift in the
 self-improvement entry; repeated drift on the same alias means the tier
 alias or provider config is wrong.
 
+Unverifiable child model = **UNVERIFIED DRAFT** lane. A child whose meta is
+missing, unreadable, or carries a single merged `model` instead of both
+model fields cannot be compared, and an impossible comparison is not a pass.
+Its output may be used as input but is never `validated` until re-checked
+under a pinned model. Run the gate over the batch directory before you
+report `validated`:
+
+```bash
+scripts/enforce-models --check-meta ~/.hermes/cache/delegation/live/<batch-id>
+```
+
+Exit 1 means drift or unverifiable; either way the batch is not validated.
+
 ## Operating loop
 
 1. Load the universal `beastmode` skill first. Read the acceptance contract
@@ -179,7 +192,7 @@ Universal Beastmode artifacts, written in this order:
 
 ## See also
 
-- `beastmode` (v2.2.0) - the canonical framework this adapter implements
+- `beastmode` (v2.3.0) - the canonical framework this adapter implements
 - `schema/acn-contract.json` - machine source of truth for the batch / task
  / meta.json shapes
 - `references/autonomy-levels.md` - the three-level scale and surfacing rules

--- a/pi/SKILL.md
+++ b/pi/SKILL.md
@@ -219,10 +219,20 @@ Beastmode's universal artifacts, written in this order:
 1. **Worker run record** — harness-specific. With pi-dynamic-workflows, this
    is the workflow run journal (id, phases, agent transcripts, token / cost
    per agent, real `usage` blocks) — export or reference it; the universal
-   shape is `{"id", "model", "stop_reason", "usage": {"input_tokens",
-   "output_tokens"}}`. For runs that used external CLI lanes (qwen-agent,
-   droid exec, MiniMax curl), persist a `meta.json` next to the run record
-   with the same shape, populated from the lane's reported usage.
+   shape is the one in `schema/acn-contract.json`: `{"id",
+   "requested_model", "actual_model", "stop_reason", "usage":
+   {"input_tokens", "output_tokens"}, "files_changed", "commands_run",
+   "verify"}`. For runs that used external CLI lanes (qwen-agent, droid
+   exec, MiniMax curl), persist a `meta.json` next to the run record with
+   the same shape, populated from the lane's reported usage.
+
+   `requested_model` is what the batch pinned; `actual_model` is what the
+   lane reports it actually ran. Both are required — a record with one
+   merged `model` field cannot prove drift in either direction, and
+   `scripts/enforce-models --check-meta` fails it as **unverifiable**
+   rather than passing it. Verify a run's records with
+   `scripts/enforce-models --check-meta <run-dir>` before claiming
+   `validated`.
 2. **Acceptance contract delta** — update the contract file (the one from
    Step 3) with actual vs planned for each acceptance bullet, and the
    verification commands that passed.

--- a/references/acn-contract.md
+++ b/references/acn-contract.md
@@ -75,7 +75,32 @@ autonomy level, blocks `validated` until the same task is re-run under the
 pinned model. Drift is fail-closed: a drifted child is treated as
 unverified draft, even if the output looks plausible.
 
-## The six shared rules
+`requested_model` and `actual_model` are separate fields on purpose. A child
+that reports a single merged `model` - the pre-v2.3 shape - gives the gate
+nothing to compare, and a comparison that cannot be made is not a pass.
+
+### Three verdicts, two of them failures
+
+| Verdict | Condition | Gate |
+|---|---|---|
+| `ok` | `requested_model == actual_model` | pass |
+| `drift` | `requested_model != actual_model` | **fail** - re-run under the pinned model |
+| `unverifiable` | meta missing, unreadable, or missing either model field | **fail** - provenance cannot be established |
+
+`unverifiable` is a gate failure because shared rule 2 already says so: a
+child whose model the runtime cannot prove is an unverified draft lane. A
+gate that exits 0 on "I don't know" inverts that rule, which is exactly what
+the pre-v2.3 tooling did - legacy-shape metas were skipped as unrecognised,
+and a run directory with no metas at all reported clean.
+
+A batch that legitimately produced no children is asserted, not assumed:
+pass `--allow-empty` to `enforce-models --check-meta` / `acn-report`.
+
+Both tools call one checker, `scripts/lib/acn_meta.py`, which reads
+`meta_json_required_fields` out of `schema/acn-contract.json`. The schema is
+load-bearing: change the field list there and the gate follows.
+
+## The seven shared rules
 
 1. **Preflight seats** before any batch - director / watcher / executor
  models resolve against the harness's known-model list. Missing model
@@ -94,6 +119,10 @@ unverified draft, even if the output looks plausible.
  to the watcher for adversarial review.
 6. **MODEL DRIFT always surfaces.** At every autonomy level. Blocks
  `validated`. Recorded in the self-improvement entry.
+7. **Unprovable provenance fails closed.** A child that is `unverifiable`
+ fails the gate exactly like a drifted one. Silence is not consent: an
+ empty run directory, an unreadable meta, or a meta without both model
+ fields all block `validated`.
 
 ## Harness primitive map
 
@@ -115,3 +144,7 @@ thing that changes.
 batch fields, task fields, meta.json fields, drift policy, hard rules.
 This doc is the human reading of it. When the schema changes, update
 this doc in the same PR; do not let the prose drift from the JSON.
+
+`tests/test-acn-parity.sh` enforces that: it asserts every field name in the
+meta.json block above appears in the schema's `meta_json_required_fields` and
+vice versa, so prose and JSON cannot silently diverge again.

--- a/references/acn-contract.md
+++ b/references/acn-contract.md
@@ -85,7 +85,11 @@ nothing to compare, and a comparison that cannot be made is not a pass.
 |---|---|---|
 | `ok` | `requested_model == actual_model` | pass |
 | `drift` | `requested_model != actual_model` | **fail** - re-run under the pinned model |
-| `unverifiable` | meta missing, unreadable, or missing either model field | **fail** - provenance cannot be established |
+| `unverifiable` | meta missing, unreadable, missing either model field, or an expected child that wrote no meta at all | **fail** - provenance cannot be established |
+
+One valid sibling does not carry a batch. Each child is judged on its own
+record, so a run where nine children proved their model and one did not is a
+failed gate, not a 90% pass.
 
 `unverifiable` is a gate failure because shared rule 2 already says so: a
 child whose model the runtime cannot prove is an unverified draft lane. A
@@ -95,6 +99,21 @@ and a run directory with no metas at all reported clean.
 
 A batch that legitimately produced no children is asserted, not assumed:
 pass `--allow-empty` to `enforce-models --check-meta` / `acn-report`.
+
+### Catching a child that never wrote anything
+
+Scanning a run directory can only judge records that exist. A worker killed
+before it wrote any meta leaves no file, so a surviving sibling would carry
+the batch to a clean exit. Pass the batch's expected child ids to close that:
+
+```bash
+enforce-models --check-meta <run-dir> --expect <batch.json>   # reads tasks[].id
+enforce-models --check-meta <run-dir> --expect child-1,child-2
+```
+
+The manifest is not a new artifact - `tasks[].id` is already required by
+`schema/acn-contract.json`, so the batch the director already wrote *is* the
+list of children the gate should expect to hear from.
 
 Both tools call one checker, `scripts/lib/acn_meta.py`, which reads
 `meta_json_required_fields` out of `schema/acn-contract.json`. The schema is

--- a/references/autonomy-levels.md
+++ b/references/autonomy-levels.md
@@ -44,8 +44,12 @@ reports accumulate into the final output in order.
 
 **MODEL DRIFT** = a task was served by a model other than the requested
 `provider/model` — router fallback, harness default, or silent substitution.
-Detect it by comparing the worker `meta.json` `model` field (or harness
-journal) against the resolved tier alias. Drift surfaces at **every** level,
+Detect it by comparing the worker `meta.json` `actual_model` against its
+`requested_model` (shape: `schema/acn-contract.json`; tooling:
+`scripts/enforce-models --check-meta` and `scripts/acn-report`, both of which
+run the same checker in `scripts/lib/acn_meta.py`). A meta that carries only a
+single `model` field cannot prove drift either way — it is **unverifiable**,
+which fails the gate exactly like drift does. Drift surfaces at **every** level,
 including high, because it breaks two guarantees at once: cost (a frontier
 substitute burns budget) and trust (an economy substitute on design-tier work
 skips the judgment the gate assumed). Drifted work is not `validated` until
@@ -89,5 +93,10 @@ bm "ship the new ingest endpoint behind a feature flag" \
 ```
 
 Worker prompt contract (universal — see `pi/SKILL.md`):
-workers never commit/push, never reach secrets, never publish, return a
-meta.json shape `{"id","model","stop_reason","usage":{...}}`.
+workers never commit/push, never reach secrets, never publish, and return the
+meta.json shape declared in `schema/acn-contract.json`:
+`{"id","requested_model","actual_model","stop_reason","usage":{...},"files_changed","commands_run","verify"}`.
+
+`requested_model` and `actual_model` are both required and must be separate
+fields. A worker that reports one merged `model` gives the gate nothing to
+compare, and an unprovable child is never `validated`.

--- a/schema/acn-contract.json
+++ b/schema/acn-contract.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0",
+  "version": "1.1",
   "concurrency_default": 3,
   "isolation": "worktree preferred when workers edit",
   "background": "director does not block the chat path when the harness supports background fan-out; orchestrator children may wait to synthesize",
@@ -28,10 +28,14 @@
     "verify"
   ],
   "drift_policy": "actual_model != requested_model is MODEL DRIFT: always surfaces, work is not validated until re-validated under the correct tier",
+  "unverifiable_policy": "a child whose meta is missing, unreadable, or lacks either requested_model or actual_model is unverifiable: the gate fails it exactly as it fails drift, because provenance that cannot be established is not provenance. A run directory containing no child metas is unverifiable unless --allow-empty is asserted",
+  "gate_verdicts": ["ok", "drift", "unverifiable"],
+  "gate_implementation": "scripts/lib/acn_meta.py, shared by scripts/enforce-models --check-meta and scripts/acn-report",
   "hard_rules": [
     "workers never commit/push",
     "workers never access secrets",
     "no watcher, no validated",
-    "gates are blocking below high"
+    "gates are blocking below high",
+    "unprovable provenance fails closed"
   ]
 }

--- a/schema/acn-contract.json
+++ b/schema/acn-contract.json
@@ -28,7 +28,7 @@
     "verify"
   ],
   "drift_policy": "actual_model != requested_model is MODEL DRIFT: always surfaces, work is not validated until re-validated under the correct tier",
-  "unverifiable_policy": "a child whose meta is missing, unreadable, or lacks either requested_model or actual_model is unverifiable: the gate fails it exactly as it fails drift, because provenance that cannot be established is not provenance. A run directory containing no child metas is unverifiable unless --allow-empty is asserted",
+  "unverifiable_policy": "a child whose meta is missing, unreadable, or lacks either requested_model or actual_model is unverifiable: the gate fails it exactly as it fails drift, because provenance that cannot be established is not provenance. Each child is judged on its own record — a valid sibling never carries an unprovable one. A run directory containing no child metas is unverifiable unless --allow-empty is asserted, and a child listed in tasks[].id that wrote no meta at all is unverifiable when the batch ids are supplied via --expect",
   "gate_verdicts": ["ok", "drift", "unverifiable"],
   "gate_implementation": "scripts/lib/acn_meta.py, shared by scripts/enforce-models --check-meta and scripts/acn-report",
   "hard_rules": [

--- a/scripts/acn-report
+++ b/scripts/acn-report
@@ -1,116 +1,115 @@
 #!/usr/bin/env python3
 """acn-report — print a phase usage report from a directory of meta.json files.
 
-Each meta.json has the shape:
+Each meta.json has the shape declared in `schema/acn-contract.json`:
 
     {
       "id": "child-1",
       "requested_model": "anthropic/claude-opus-4-7",
       "actual_model":    "anthropic/claude-opus-4-7",
-      "usage": {"input_tokens": 1234, "output_tokens": 567}
+      "stop_reason":     "end_turn",
+      "usage": {"input_tokens": 1234, "output_tokens": 567},
+      "files_changed": [...], "commands_run": [...], "verify": {...}
     }
 
-Missing fields are reported as "unavailable". Drift (requested != actual)
-exits with code 1.
+Missing usage fields are reported as "unavailable". The model-provenance
+gate — MODEL DRIFT, and children whose model cannot be proven at all — is
+`scripts/lib/acn_meta.py`, the same module `enforce-models --check-meta`
+runs, so the two tools cannot disagree about whether a batch is validated.
+
+Exit codes: 0 clean, 1 gate failure (drift or unverifiable), 2 usage error.
 
 Usage:
-    acn-report <dir-of-meta.json>
+    acn-report <dir-of-meta.json> [--allow-empty] [--strict]
 """
 
 from __future__ import annotations
 
-import json
 import sys
 from pathlib import Path
 
-UNAVAILABLE = "unavailable"
+sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+
+import acn_meta  # noqa: E402  (path is set immediately above)
+
+UNAVAILABLE = acn_meta.UNAVAILABLE
 
 
-def load_meta(path: Path) -> dict:
-    try:
-        with path.open() as f:
-            return json.load(f)
-    except (OSError, json.JSONDecodeError) as e:
-        # Treat a broken meta as a fully-unavailable row so the report still
-        # surfaces the issue rather than silently dropping the child.
-        return {
-            "id": path.stem,
-            "_error": str(e),
-            "requested_model": UNAVAILABLE,
-            "actual_model": UNAVAILABLE,
-            "usage": {"input_tokens": UNAVAILABLE, "output_tokens": UNAVAILABLE},
-        }
-
-
-def field(d: dict, *keys: str) -> str:
-    for k in keys:
-        v = d.get(k)
-        if v is not None and v != "":
-            return str(v)
-    return UNAVAILABLE
-
-
-def usage_field(d: dict, key: str) -> str:
-    u = d.get("usage")
-    if not isinstance(u, dict):
-        return UNAVAILABLE
-    v = u.get(key)
-    return UNAVAILABLE if v is None else str(v)
+def usage() -> int:
+    print("usage: acn-report <dir-of-meta.json> [--allow-empty] [--strict]",
+          file=sys.stderr)
+    return 2
 
 
 def main() -> int:
-    if len(sys.argv) != 2:
-        print("usage: acn-report <dir-of-meta.json>", file=sys.stderr)
-        return 2
-    target = Path(sys.argv[1])
-    if not target.is_dir():
-        print(f"acn-report: not a directory: {target}", file=sys.stderr)
+    allow_empty = False
+    strict = False
+    positional: list[str] = []
+    for arg in sys.argv[1:]:
+        if arg == "--allow-empty":
+            allow_empty = True
+        elif arg == "--strict":
+            strict = True
+        elif arg.startswith("-"):
+            print(f"acn-report: unknown arg: {arg}", file=sys.stderr)
+            return usage()
+        else:
+            positional.append(arg)
+    if len(positional) != 1:
+        return usage()
+
+    target = Path(positional[0])
+    result = acn_meta.check(target, allow_empty=allow_empty, strict=strict)
+    if result.exit_code == 2:
+        for message in result.messages:
+            print(f"acn-report: {message}", file=sys.stderr)
         return 2
 
-    # Literal meta.json anywhere plus top-level *.json that looks like meta.
-    candidates = sorted(
-        set(target.glob("*.json")) | set(target.glob("**/meta.json"))
-    )
-    if not candidates:
-        print(f"acn-report: no meta files found in {target}", file=sys.stderr)
-        return 0
+    if not result.rows:
+        for message in result.messages:
+            print(f"acn-report: {message}", file=sys.stderr)
+        return result.exit_code
 
     requested_overall = UNAVAILABLE
     actual_lines: list[str] = []
-    drift_ids: list[str] = []
-    any_drift = False
 
     print("Per-child usage:")
     print("-" * 72)
-    for path in candidates:
-        d = load_meta(path)
-        cid = field(d, "id", "name")
-        req = field(d, "requested_model")
-        act = field(d, "actual_model")
-        in_tok = usage_field(d, "input_tokens")
-        out_tok = usage_field(d, "output_tokens")
-        print(f"  {cid}")
-        print(f"    requested: {req}")
-        print(f"    actual:    {act}")
-        print(f"    tokens:    in={in_tok} out={out_tok}")
-        if req != act:
-            any_drift = True
-            drift_ids.append(cid)
-        if requested_overall == UNAVAILABLE and req != UNAVAILABLE:
-            requested_overall = req
-        if act != UNAVAILABLE:
-            actual_lines.append(f"{act} per task")
+    for row in result.rows:
+        print(f"  {row.id}")
+        print(f"    requested: {row.requested}")
+        print(f"    actual:    {row.actual}")
+        print(f"    tokens:    in={row.input_tokens} out={row.output_tokens}")
+        if row.missing_fields:
+            print(f"    incomplete: missing {', '.join(row.missing_fields)}")
+        if requested_overall == UNAVAILABLE and row.requested != UNAVAILABLE:
+            requested_overall = row.requested
+        if row.actual != UNAVAILABLE:
+            actual_lines.append(f"{row.actual} per task")
     print("-" * 72)
     print()
 
     actual_summary = ", ".join(actual_lines) if actual_lines else UNAVAILABLE
     print(f"Models: requested {requested_overall} -> actual {actual_summary}")
-    if any_drift:
-        print(f"Drift: MODEL DRIFT: {requested_overall} -> see per-child rows on {', '.join(drift_ids)}")
+
+    drifted = [r for r in result.rows if r.status == acn_meta.DRIFT]
+    unproven = [r for r in result.rows if r.status == acn_meta.UNVERIFIABLE]
+    if drifted:
+        ids = ", ".join(r.id for r in drifted)
+        print(f"Drift: MODEL DRIFT: {requested_overall} -> see per-child rows on {ids}")
     else:
         print("Drift: none")
 
-    return 1 if any_drift else 0
+    # Unprovable provenance is its own line: it is not drift, but under ACN
+    # shared rule 2 it blocks `validated` just the same. Reporting it as
+    # "Drift: none" — which is what this tool used to do — reads as a pass.
+    if unproven:
+        print("Unverifiable: "
+              + "; ".join(f"{r.id} ({r.reason})" for r in unproven))
+        print("Unverifiable children are not `validated` — re-run them under a "
+              "pinned model that reports requested_model and actual_model.")
+
+    return result.exit_code
 
 
 if __name__ == "__main__":

--- a/scripts/acn-report
+++ b/scripts/acn-report
@@ -36,20 +36,32 @@ UNAVAILABLE = acn_meta.UNAVAILABLE
 
 
 def usage() -> int:
-    print("usage: acn-report <dir-of-meta.json> [--allow-empty] [--strict]",
-          file=sys.stderr)
+    print("usage: acn-report <dir-of-meta.json> [--expect <batch.json|id,...>] "
+          "[--allow-empty] [--strict]", file=sys.stderr)
     return 2
 
 
 def main() -> int:
     allow_empty = False
     strict = False
+    expect = None
     positional: list[str] = []
-    for arg in sys.argv[1:]:
+    args = sys.argv[1:]
+    while args:
+        arg = args.pop(0)
         if arg == "--allow-empty":
             allow_empty = True
         elif arg == "--strict":
             strict = True
+        elif arg == "--expect":
+            if not args:
+                print("acn-report: --expect needs a batch file or id list", file=sys.stderr)
+                return usage()
+            try:
+                expect = acn_meta.expected_ids(args.pop(0))
+            except Exception as e:
+                print(f"acn-report: --expect: {e}", file=sys.stderr)
+                return 2
         elif arg.startswith("-"):
             print(f"acn-report: unknown arg: {arg}", file=sys.stderr)
             return usage()
@@ -59,7 +71,7 @@ def main() -> int:
         return usage()
 
     target = Path(positional[0])
-    result = acn_meta.check(target, allow_empty=allow_empty, strict=strict)
+    result = acn_meta.check(target, allow_empty=allow_empty, strict=strict, expect=expect)
     if result.exit_code == 2:
         for message in result.messages:
             print(f"acn-report: {message}", file=sys.stderr)

--- a/scripts/bm
+++ b/scripts/bm
@@ -165,7 +165,15 @@ GATE_PROMPT="$(bm_gate_prompt "$AUTONOMY")"
 SEAT_PROMPT="Seats: director=$FRONTIER economy=$ECONOMY watcher=${WATCHER:-unset}. Pin the executor model on every child; never let economy work inherit a session default. Each child returns meta.json with requested_model and actual_model."
 PI_ARGS=(--skill ~/.agents/skills/beastmode-pi/SKILL.md --print --no-session --thinking "$THINKING" --append-system-prompt "$PHASE_PROMPT $MODEL_FAILURE_PROMPT $GATE_PROMPT $SEAT_PROMPT")
 [ -n "$FRONTIER" ]     && PI_ARGS+=(--model "$FRONTIER")
-[ -n "$ECONOMY" ]      && PI_ARGS+=(--models "$FRONTIER,$ECONOMY")
+# ponytail: build the --models list from the seats that were actually set.
+# `--models "$FRONTIER,$ECONOMY"` handed pi a leading comma whenever --economy
+# was given without --frontier, which is a legal invocation.
+MODELS_CSV=""
+for seat_model in "$FRONTIER" "$ECONOMY"; do
+  [ -z "$seat_model" ] && continue
+  MODELS_CSV="${MODELS_CSV:+$MODELS_CSV,}$seat_model"
+done
+[ -n "$ECONOMY" ]      && PI_ARGS+=(--models "$MODELS_CSV")
 [ "$AUTONOMY" = "low" ]  && PI_ARGS+=(--approve)
 [ "$AUTONOMY" = "high" ] && PI_ARGS+=(--no-builtin-tools)
 
@@ -176,16 +184,22 @@ if [ "$ON" != "local" ]; then
   if ! command -v ssh >/dev/null 2>&1; then
     echo "bm: --on $ON needs ssh in PATH" >&2; exit 2
   fi
-  REMOTE_FLAGS=""
-  [ "$GSD" = "1" ]       && REMOTE_FLAGS="$REMOTE_FLAGS --gsd"
-  REMOTE_FLAGS="$REMOTE_FLAGS --harness $HARNESS"
-  [ -n "$FRONTIER" ]     && REMOTE_FLAGS="$REMOTE_FLAGS --frontier $FRONTIER"
-  [ -n "$ECONOMY" ]      && REMOTE_FLAGS="$REMOTE_FLAGS --economy $ECONOMY"
-  [ -n "$WATCHER" ]      && REMOTE_FLAGS="$REMOTE_FLAGS --watcher $WATCHER"
-  REMOTE_FLAGS="$REMOTE_FLAGS --autonomy $AUTONOMY"
-  REMOTE_FLAGS="$REMOTE_FLAGS --thinking $THINKING"
-  # shellcheck disable=SC2086
-  exec ssh "$ON" "bm '$GOAL' $REMOTE_FLAGS"
+  # ponytail: everything crossing the ssh boundary gets single-quoted with
+  # embedded quotes escaped. The old form spliced the raw goal into
+  # `bm '$GOAL' ...`, so any apostrophe ("don't drop the index") ended the
+  # quote and the rest of the goal was executed as remote shell words.
+  # POSIX single-quoting rather than printf %q — %q can emit bash-only
+  # $'...' forms and the remote login shell is not guaranteed to be bash.
+  shquote() { printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"; }
+  REMOTE_CMD="bm $(shquote "$GOAL")"
+  [ "$GSD" = "1" ]   && REMOTE_CMD="$REMOTE_CMD --gsd"
+  REMOTE_CMD="$REMOTE_CMD --harness $(shquote "$HARNESS")"
+  [ -n "$FRONTIER" ] && REMOTE_CMD="$REMOTE_CMD --frontier $(shquote "$FRONTIER")"
+  [ -n "$ECONOMY" ]  && REMOTE_CMD="$REMOTE_CMD --economy $(shquote "$ECONOMY")"
+  [ -n "$WATCHER" ]  && REMOTE_CMD="$REMOTE_CMD --watcher $(shquote "$WATCHER")"
+  REMOTE_CMD="$REMOTE_CMD --autonomy $(shquote "$AUTONOMY")"
+  REMOTE_CMD="$REMOTE_CMD --thinking $(shquote "$THINKING")"
+  exec ssh "$ON" "$REMOTE_CMD"
 fi
 
 # Harness dispatch. Every harness gets the SAME phase/gate/model-failure
@@ -220,8 +234,13 @@ case "$HARNESS" in
     ;;
   claude)
     # Claude Code: print-mode one-shot. Adapter: adapters/claude-code/SKILL.md.
+    # ponytail: the claude CLI takes a bare model id, not provider/model —
+    # `--frontier opus` resolves to anthropic/claude-opus-4-7 and the CLI
+    # rejects the provider half. Strip it here, the way the hermes branch
+    # already splits provider from model, instead of asking the caller to
+    # remember which harness wants which form.
     C_ARGS=(-p "$FULL_PROMPT")
-    [ -n "$FRONTIER" ] && C_ARGS+=(--model "$FRONTIER")
+    [ -n "$FRONTIER" ] && C_ARGS+=(--model "${FRONTIER#*/}")
     [ "$AUTONOMY" = "high" ] && C_ARGS+=(--dangerously-skip-permissions)
     exec claude "${C_ARGS[@]}"
     ;;

--- a/scripts/enforce-models
+++ b/scripts/enforce-models
@@ -5,21 +5,27 @@
 #   enforce-models --harness pi|hermes|claude|codex --model provider/model [...]
 #
 # Postflight (scans a directory of meta.json files):
-#   enforce-models --check-meta <dir>
+#   enforce-models --check-meta <dir> [--allow-empty] [--strict]
 #
 # Exit codes:
-#   0  all requested models available OR no drift detected
-#   1  drift detected (postflight)
+#   0  all requested models available OR every child's model is proven correct
+#   1  postflight gate failure: MODEL DRIFT, or a child whose model cannot be
+#      proven at all (ACN shared rule 2 — unprovable is never `validated`)
 #   2  usage / preflight failure (missing model)
+#
+# --allow-empty  a batch with zero children is a pass, not a gate failure
+# --strict       also fail on metas missing schema-required fields
 #
 # Bypass: BM_SKIP_MODEL_CHECK=1 makes preflight a no-op pass-through.
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
 usage() {
   cat >&2 <<'USAGE'
 usage: enforce-models --harness pi|hermes|claude|codex --model provider/model [...]
-       enforce-models --check-meta <dir>
+       enforce-models --check-meta <dir> [--allow-empty] [--strict]
 USAGE
   exit 2
 }
@@ -27,10 +33,10 @@ USAGE
 [ $# -ge 1 ] || usage
 
 # ---- arg parse ----
-MODE=""        # preflight | postflight
 HARNESS=""
 MODELS=()
 META_DIR=""
+META_FLAGS=()
 while [ $# -gt 0 ]; do
   case "$1" in
     --harness)    HARNESS="${2:-}"; shift 2 ;;
@@ -38,56 +44,27 @@ while [ $# -gt 0 ]; do
     --model)      MODELS+=("${2:-}"); shift 2 ;;
     --model=*)    MODELS+=("${1#*=}"); shift ;;
     --check-meta) META_DIR="${2:-}"; shift 2 ;;
+    --allow-empty) META_FLAGS+=(--allow-empty); shift ;;
+    --strict)     META_FLAGS+=(--strict); shift ;;
     -h|--help)    usage ;;
     *)            echo "enforce-models: unknown arg: $1" >&2; usage ;;
   esac
 done
 
 # ---- postflight ----
+# ponytail: the provenance gate itself lives in scripts/lib/acn_meta.py, which
+# scripts/acn-report imports too. Two readings of one contract is how a child
+# ends up passing in one tool and failing in the other, so this branch is a
+# thin shell over the shared checker rather than a second implementation.
 if [ -n "$META_DIR" ]; then
   if [ ! -d "$META_DIR" ]; then
     echo "enforce-models: --check-meta dir not found: $META_DIR" >&2
     exit 2
   fi
-  # ponytail: one python pass, json + simple comparison — no jq, no extra deps.
-  # Tolerates missing meta fields so a half-written ACN run still gets reported.
-  # Wrap in `set +e` so a non-zero python exit (drift detected) doesn't trip
-  # `set -euo pipefail` before we get a chance to print the report.
   set +e
-  drift_out="$(META_DIR="$META_DIR" python3 - <<'PY'
-import json, os, sys, glob
-mydir = os.environ["META_DIR"]
-# Match any *.json anywhere in the tree (top level + nested child dirs).
-# ACN runs nest meta.json per child id; we want them all.
-candidates = sorted(set(glob.glob(os.path.join(mydir, "**", "*.json"), recursive=True)))
-if not candidates:
-    sys.stderr.write("no meta files found\n")
-    sys.exit(0)
-drift = 0
-for path in candidates:
-    try:
-        with open(path) as f:
-            d = json.load(f)
-    except Exception as e:
-        print(f"enforce-models: bad JSON in {path}: {e}", file=sys.stderr)
-        drift = 1
-        continue
-    req = d.get("requested_model")
-    act = d.get("actual_model")
-    if req is None and act is None:
-        # not a meta file we recognise, skip
-        continue
-    if req != act:
-        print(f"MODEL DRIFT: {req} -> {act} ({path})")
-        drift = 1
-sys.exit(drift)
-PY
-  )"
+  python3 "$SCRIPT_DIR/lib/acn_meta.py" --check "$META_DIR" "${META_FLAGS[@]+"${META_FLAGS[@]}"}"
   rc=$?
   set -e
-  if [ -n "$drift_out" ]; then
-    echo "$drift_out"
-  fi
   exit $rc
 fi
 
@@ -181,22 +158,21 @@ case "$HARNESS" in
       echo "enforce-models: claude not in PATH; install claude or set BM_SKIP_MODEL_CHECK=1" >&2
       exit 2
     fi
-    # ponytail: claude pins its own model namespace; if you want a non-claude
-    # model through this harness, you're using the wrong harness. Warn, not
-    # fail — the runner will error out if it truly cannot dispatch.
-    missing=()
-    for model in "${MODELS[@]}"; do
-      [[ "$model" == claude-* ]] || {
-        echo "enforce-models: warning: harness=claude but model does not start with claude- ($model)" >&2
-      }
-      if ! claude --version >/dev/null 2>&1; then
-        missing+=("$model")
-      fi
-    done
-    if [ "${#missing[@]}" -gt 0 ]; then
+    if ! claude --version >/dev/null 2>&1; then
       echo "enforce-models: claude harness unavailable on this host" >&2
       exit 2
     fi
+    # ponytail: claude pins its own model namespace; if you want a non-claude
+    # model through this harness, you're using the wrong harness. Warn, not
+    # fail — the runner will error out if it truly cannot dispatch. Compare
+    # the model half only: aliases resolve to provider/model, and bm strips
+    # the provider before handing it to the CLI, so `anthropic/claude-opus-4-7`
+    # is a correct request and used to warn on every single invocation.
+    for model in "${MODELS[@]}"; do
+      [[ "${model#*/}" == claude-* ]] || {
+        echo "enforce-models: warning: harness=claude but model does not start with claude- ($model)" >&2
+      }
+    done
     ;;
 
   codex)

--- a/scripts/enforce-models
+++ b/scripts/enforce-models
@@ -5,7 +5,8 @@
 #   enforce-models --harness pi|hermes|claude|codex --model provider/model [...]
 #
 # Postflight (scans a directory of meta.json files):
-#   enforce-models --check-meta <dir> [--allow-empty] [--strict]
+#   enforce-models --check-meta <dir> [--expect <batch.json|id,...>]
+#                                     [--allow-empty] [--strict]
 #
 # Exit codes:
 #   0  all requested models available OR every child's model is proven correct
@@ -13,6 +14,9 @@
 #      proven at all (ACN shared rule 2 — unprovable is never `validated`)
 #   2  usage / preflight failure (missing model)
 #
+# --expect       the batch's expected child ids, so a child that died before
+#                writing any meta is caught. Scanning what is present can
+#                never notice a file that was never created.
 # --allow-empty  a batch with zero children is a pass, not a gate failure
 # --strict       also fail on metas missing schema-required fields
 #
@@ -25,7 +29,8 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 usage() {
   cat >&2 <<'USAGE'
 usage: enforce-models --harness pi|hermes|claude|codex --model provider/model [...]
-       enforce-models --check-meta <dir> [--allow-empty] [--strict]
+       enforce-models --check-meta <dir> [--expect <batch.json|id,...>]
+                                         [--allow-empty] [--strict]
 USAGE
   exit 2
 }
@@ -44,6 +49,8 @@ while [ $# -gt 0 ]; do
     --model)      MODELS+=("${2:-}"); shift 2 ;;
     --model=*)    MODELS+=("${1#*=}"); shift ;;
     --check-meta) META_DIR="${2:-}"; shift 2 ;;
+    --expect)     META_FLAGS+=(--expect "${2:-}"); shift 2 ;;
+    --expect=*)   META_FLAGS+=(--expect "${1#*=}"); shift ;;
     --allow-empty) META_FLAGS+=(--allow-empty); shift ;;
     --strict)     META_FLAGS+=(--strict); shift ;;
     -h|--help)    usage ;;

--- a/scripts/lib/acn_meta.py
+++ b/scripts/lib/acn_meta.py
@@ -70,6 +70,14 @@ DEFAULT_META_FIELDS = (
 # meta would carry. Run dirs legitimately contain other JSON (harness config,
 # task manifests); classifying those as unverifiable children would turn the
 # fail-closed gate into a false-positive machine.
+#
+# Marker choice is load-bearing in BOTH directions, and the first cut of this
+# got it wrong: requiring a provenance field to recognise a child meant a child
+# that died before writing one was not a child, so it vanished from the report
+# and a sibling's clean row carried the batch to exit 0. That is the same
+# fail-open this module exists to close, just one level up. Recognition must
+# therefore key on "this is a child record", never on "this child proved
+# something" — deciding whether it proved anything is `classify`'s job.
 META_MARKERS = (
     "requested_model",
     "actual_model",
@@ -77,11 +85,15 @@ META_MARKERS = (
     "files_changed",
     "commands_run",
     "verify",
+    # A token-usage block is the one field no harness config carries, so it
+    # identifies a half-written child that has nothing else left to match on.
+    "usage",
 )
-# Pre-v2.3 shape: no requested/actual pair, just the model that ran. Matched
-# so the gate can name it and tell the caller how to migrate, instead of
-# skipping it silently.
-LEGACY_MARKERS = ("model", "usage")
+# Pre-v2.3 shape: no requested/actual pair, just the model that ran. `model`
+# needs a companion field — a bare {"model": ...} is as likely to be provider
+# config as a child record, and false-failing a config file would train people
+# to pass --allow-empty everywhere.
+LEGACY_PAIRS = (("model", "id"), ("model", "usage"), ("model", "stop_reason"))
 
 
 def contract_path(start: Path | None = None) -> Path | None:
@@ -111,6 +123,18 @@ def required_meta_fields() -> tuple[str, ...]:
     return DEFAULT_META_FIELDS
 
 
+def is_child_record(body: dict) -> bool:
+    """Does this JSON body look like an ACN child record at all?
+
+    Deliberately not "does it prove its model" — see the note on META_MARKERS.
+    """
+    if not isinstance(body, dict):
+        return False
+    if any(k in body for k in META_MARKERS):
+        return True
+    return any(all(k in body for k in pair) for pair in LEGACY_PAIRS)
+
+
 def find_meta_files(target: Path) -> list[Path]:
     """Every candidate child meta under `target`, recursively, sorted."""
     found = []
@@ -130,11 +154,7 @@ def find_meta_files(target: Path) -> list[Path]:
             continue
         except OSError:
             continue
-        if not isinstance(body, dict):
-            continue
-        if any(k in body for k in META_MARKERS):
-            found.append(path)
-        elif all(k in body for k in LEGACY_MARKERS):
+        if is_child_record(body):
             found.append(path)
     return found
 
@@ -213,13 +233,32 @@ class GateResult:
         self.exit_code = exit_code
 
 
-def check(target: Path, allow_empty: bool = False, strict: bool = False) -> GateResult:
+def expected_ids(source: str) -> list[str]:
+    """Expected child ids, from a batch JSON path or a comma-separated list.
+
+    The batch already declares its children — `tasks[].id` is required by
+    `schema/acn-contract.json` — so the manifest the gate needs to notice an
+    absent child is a file the contract guarantees exists.
+    """
+    path = Path(source)
+    if path.is_file():
+        with path.open() as f:
+            batch = json.load(f)
+        tasks = batch.get("tasks") if isinstance(batch, dict) else None
+        if not isinstance(tasks, list):
+            raise ValueError(f"{source} has no 'tasks' list to read child ids from")
+        return [str(t.get("id")) for t in tasks if isinstance(t, dict) and t.get("id")]
+    return [part.strip() for part in source.split(",") if part.strip()]
+
+
+def check(target: Path, allow_empty: bool = False, strict: bool = False,
+          expect: list[str] | None = None) -> GateResult:
     """Run the provenance gate over a directory of child metas."""
     if not target.is_dir():
         return GateResult([], [f"not a directory: {target}"], 2)
 
     rows = load_rows(target)
-    if not rows:
+    if not rows and not expect:
         if allow_empty:
             return GateResult([], [f"no child metas found in {target} (--allow-empty)"], 0)
         # Fail closed: a batch that produced no provable child did not
@@ -235,13 +274,26 @@ def check(target: Path, allow_empty: bool = False, strict: bool = False) -> Gate
         )
 
     messages = [row.line() for row in rows if row.failed]
+
+    # A child that died before writing anything leaves no file, so scanning
+    # what is present can never notice it — one surviving sibling would carry
+    # the batch to exit 0. Only the batch's own list of ids can catch that.
+    missing_children = []
+    if expect:
+        seen = {row.id for row in rows}
+        missing_children = [cid for cid in expect if cid not in seen]
+        for cid in missing_children:
+            messages.append(
+                f"UNVERIFIABLE: expected child {cid!r} wrote no meta in {target}; "
+                "it cannot be shown to have run under the pinned model"
+            )
     incomplete = [row for row in rows if row.missing_fields and not row.failed]
     for row in incomplete:
         messages.append(
             f"INCOMPLETE: {row.id} missing {', '.join(row.missing_fields)} ({row.path})"
         )
 
-    failed = any(row.failed for row in rows)
+    failed = any(row.failed for row in rows) or bool(missing_children)
     if failed or (strict and incomplete):
         return GateResult(rows, messages, 1)
     return GateResult(rows, messages, 0)
@@ -251,6 +303,7 @@ def main(argv: list[str]) -> int:
     target = None
     allow_empty = False
     strict = False
+    expect: list[str] | None = None
     args = list(argv)
     while args:
         arg = args.pop(0)
@@ -259,6 +312,15 @@ def main(argv: list[str]) -> int:
                 print("acn_meta: --check needs a directory", file=sys.stderr)
                 return 2
             target = Path(args.pop(0))
+        elif arg == "--expect":
+            if not args:
+                print("acn_meta: --expect needs a batch file or id list", file=sys.stderr)
+                return 2
+            try:
+                expect = expected_ids(args.pop(0))
+            except (OSError, ValueError, json.JSONDecodeError) as e:
+                print(f"acn_meta: --expect: {e}", file=sys.stderr)
+                return 2
         elif arg == "--allow-empty":
             allow_empty = True
         elif arg == "--strict":
@@ -271,10 +333,11 @@ def main(argv: list[str]) -> int:
             return 2
 
     if target is None:
-        print("usage: acn_meta.py --check <dir> [--allow-empty] [--strict]", file=sys.stderr)
+        print("usage: acn_meta.py --check <dir> [--expect <batch.json|id,...>] "
+              "[--allow-empty] [--strict]", file=sys.stderr)
         return 2
 
-    result = check(target, allow_empty=allow_empty, strict=strict)
+    result = check(target, allow_empty=allow_empty, strict=strict, expect=expect)
     stream = sys.stderr if result.exit_code == 2 else sys.stdout
     for message in result.messages:
         print(message, file=stream)

--- a/scripts/lib/acn_meta.py
+++ b/scripts/lib/acn_meta.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""acn_meta — the one implementation of the ACN model-provenance gate.
+
+Before v2.3 the gate existed twice: `enforce-models --check-meta` walked
+`**/*.json` and compared two fields, while `acn-report` walked `*.json` plus
+`**/meta.json` and compared the same two fields differently. Two readings of
+one contract is one reading too many — a child could pass in one tool and
+fail in the other. Both tools now call this module, and this module reads
+`schema/acn-contract.json` so the schema is load-bearing rather than
+decorative.
+
+The gate answers exactly one question per child: **can we prove which model
+served it?**
+
+    ok            requested_model == actual_model
+    drift         requested_model != actual_model
+    unverifiable  provenance cannot be established at all
+
+`unverifiable` is a failure, not a warning. ACN shared rule 2 says a child
+whose model the runtime cannot prove is an unverified draft lane and is
+never `validated`; a gate that exits 0 on "I don't know" would invert that
+rule. The pre-v2.3 code hit this in two common cases:
+
+  * a legacy `{"id", "model", "stop_reason", "usage"}` meta — the shape the
+    repo's own pi and autonomy-levels docs used to specify — parsed fine,
+    matched no known field, and was skipped as "not a meta file";
+  * an empty directory (batch died before any child wrote) returned 0.
+
+Contract *completeness* (all of `meta_json_required_fields` present) is
+reported separately and only gates under `strict`. Provenance is the gate;
+missing `commands_run` is a quality signal.
+
+Usage as a CLI (what scripts/enforce-models shells out to):
+
+    python3 acn_meta.py --check <dir> [--allow-empty] [--strict]
+
+Exit codes match the rest of the toolchain: 0 clean, 1 gate failure,
+2 usage error.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+import sys
+from pathlib import Path
+
+UNAVAILABLE = "unavailable"
+
+OK = "ok"
+DRIFT = "drift"
+UNVERIFIABLE = "unverifiable"
+
+# Fallback used only when schema/acn-contract.json cannot be located (the
+# module is vendored somewhere without the repo). Keep in sync with the
+# schema; tests/test-acn-parity.sh asserts the two agree.
+DEFAULT_META_FIELDS = (
+    "id",
+    "requested_model",
+    "actual_model",
+    "stop_reason",
+    "usage",
+    "files_changed",
+    "commands_run",
+    "verify",
+)
+
+# A *.json file under the run directory is treated as an ACN child meta when
+# it is literally named meta.json, or when its body carries a field only a
+# meta would carry. Run dirs legitimately contain other JSON (harness config,
+# task manifests); classifying those as unverifiable children would turn the
+# fail-closed gate into a false-positive machine.
+META_MARKERS = (
+    "requested_model",
+    "actual_model",
+    "stop_reason",
+    "files_changed",
+    "commands_run",
+    "verify",
+)
+# Pre-v2.3 shape: no requested/actual pair, just the model that ran. Matched
+# so the gate can name it and tell the caller how to migrate, instead of
+# skipping it silently.
+LEGACY_MARKERS = ("model", "usage")
+
+
+def contract_path(start: Path | None = None) -> Path | None:
+    """Locate schema/acn-contract.json by walking up from this file."""
+    here = (start or Path(__file__).resolve()).parent
+    for candidate in (here, *here.parents):
+        path = candidate / "schema" / "acn-contract.json"
+        if path.is_file():
+            return path
+    return None
+
+
+@functools.lru_cache(maxsize=1)
+def required_meta_fields() -> tuple[str, ...]:
+    """The contract's meta.json required fields, schema-first."""
+    path = contract_path()
+    if path is None:
+        return DEFAULT_META_FIELDS
+    try:
+        with path.open() as f:
+            contract = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return DEFAULT_META_FIELDS
+    fields = contract.get("meta_json_required_fields")
+    if isinstance(fields, list) and fields:
+        return tuple(str(x) for x in fields)
+    return DEFAULT_META_FIELDS
+
+
+def find_meta_files(target: Path) -> list[Path]:
+    """Every candidate child meta under `target`, recursively, sorted."""
+    found = []
+    for path in sorted(set(target.glob("**/*.json"))):
+        if not path.is_file():
+            continue
+        if path.name == "meta.json":
+            found.append(path)
+            continue
+        try:
+            with path.open() as f:
+                body = json.load(f)
+        except json.JSONDecodeError:
+            # Unreadable JSON inside a run dir is itself a finding — a child
+            # that half-wrote its meta must not pass as "no meta here".
+            found.append(path)
+            continue
+        except OSError:
+            continue
+        if not isinstance(body, dict):
+            continue
+        if any(k in body for k in META_MARKERS):
+            found.append(path)
+        elif all(k in body for k in LEGACY_MARKERS):
+            found.append(path)
+    return found
+
+
+class Row:
+    """One child's provenance verdict, ready for either tool's output."""
+
+    def __init__(self, path: Path, data: dict | None, error: str | None = None):
+        self.path = path
+        self.error = error
+        data = data if isinstance(data, dict) else {}
+        self.id = _first(data, "id", "name") or path.stem
+        self.requested = _first(data, "requested_model") or UNAVAILABLE
+        self.actual = _first(data, "actual_model") or UNAVAILABLE
+        self.legacy_model = _first(data, "model") or UNAVAILABLE
+        usage = data.get("usage")
+        usage = usage if isinstance(usage, dict) else {}
+        self.input_tokens = _stringify(usage.get("input_tokens"))
+        self.output_tokens = _stringify(usage.get("output_tokens"))
+        self.missing_fields = [f for f in required_meta_fields() if f not in data]
+        self.status, self.reason = self._classify()
+
+    def _classify(self) -> tuple[str, str]:
+        if self.error:
+            return UNVERIFIABLE, f"unreadable meta: {self.error}"
+        has_req = self.requested != UNAVAILABLE
+        has_act = self.actual != UNAVAILABLE
+        if has_req and has_act:
+            if self.requested == self.actual:
+                return OK, ""
+            return DRIFT, f"{self.requested} -> {self.actual}"
+        if self.legacy_model != UNAVAILABLE and not (has_req or has_act):
+            return UNVERIFIABLE, (
+                f"legacy meta shape: only 'model' ({self.legacy_model}); "
+                "emit requested_model and actual_model per schema/acn-contract.json"
+            )
+        missing = "requested_model" if not has_req else "actual_model"
+        return UNVERIFIABLE, f"missing {missing}; cannot prove which model served this child"
+
+    @property
+    def failed(self) -> bool:
+        return self.status in (DRIFT, UNVERIFIABLE)
+
+    def line(self) -> str:
+        label = "MODEL DRIFT" if self.status == DRIFT else "UNVERIFIABLE"
+        return f"{label}: {self.reason} ({self.path})"
+
+
+def _first(data: dict, *keys: str) -> str | None:
+    for key in keys:
+        value = data.get(key)
+        if value is not None and value != "":
+            return str(value)
+    return None
+
+
+def _stringify(value) -> str:
+    return UNAVAILABLE if value is None else str(value)
+
+
+def load_rows(target: Path) -> list[Row]:
+    rows = []
+    for path in find_meta_files(target):
+        try:
+            with path.open() as f:
+                rows.append(Row(path, json.load(f)))
+        except (OSError, json.JSONDecodeError) as e:
+            rows.append(Row(path, None, error=str(e)))
+    return rows
+
+
+class GateResult:
+    def __init__(self, rows: list[Row], messages: list[str], exit_code: int):
+        self.rows = rows
+        self.messages = messages
+        self.exit_code = exit_code
+
+
+def check(target: Path, allow_empty: bool = False, strict: bool = False) -> GateResult:
+    """Run the provenance gate over a directory of child metas."""
+    if not target.is_dir():
+        return GateResult([], [f"not a directory: {target}"], 2)
+
+    rows = load_rows(target)
+    if not rows:
+        if allow_empty:
+            return GateResult([], [f"no child metas found in {target} (--allow-empty)"], 0)
+        # Fail closed: a batch that produced no provable child did not
+        # produce a validated one either.
+        return GateResult(
+            [],
+            [
+                f"UNVERIFIABLE: no child metas found in {target}; "
+                "no child's model can be proven, so nothing here is validated. "
+                "Pass --allow-empty if this batch legitimately had no children."
+            ],
+            1,
+        )
+
+    messages = [row.line() for row in rows if row.failed]
+    incomplete = [row for row in rows if row.missing_fields and not row.failed]
+    for row in incomplete:
+        messages.append(
+            f"INCOMPLETE: {row.id} missing {', '.join(row.missing_fields)} ({row.path})"
+        )
+
+    failed = any(row.failed for row in rows)
+    if failed or (strict and incomplete):
+        return GateResult(rows, messages, 1)
+    return GateResult(rows, messages, 0)
+
+
+def main(argv: list[str]) -> int:
+    target = None
+    allow_empty = False
+    strict = False
+    args = list(argv)
+    while args:
+        arg = args.pop(0)
+        if arg == "--check":
+            if not args:
+                print("acn_meta: --check needs a directory", file=sys.stderr)
+                return 2
+            target = Path(args.pop(0))
+        elif arg == "--allow-empty":
+            allow_empty = True
+        elif arg == "--strict":
+            strict = True
+        elif arg in ("-h", "--help"):
+            print(__doc__)
+            return 0
+        else:
+            print(f"acn_meta: unknown arg: {arg}", file=sys.stderr)
+            return 2
+
+    if target is None:
+        print("usage: acn_meta.py --check <dir> [--allow-empty] [--strict]", file=sys.stderr)
+        return 2
+
+    result = check(target, allow_empty=allow_empty, strict=strict)
+    stream = sys.stderr if result.exit_code == 2 else sys.stdout
+    for message in result.messages:
+        print(message, file=stream)
+    return result.exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/fixtures/acn-meta/drift/b.json
+++ b/tests/fixtures/acn-meta/drift/b.json
@@ -1,1 +1,1 @@
-{"id": "b", "requested_model": "anthropic/claude-opus-4-7", "actual_model": "kimi-coding/k2", "usage": {"input_tokens": 1, "output_tokens": 2}}
+{"id": "b", "requested_model": "anthropic/claude-opus-4-7", "actual_model": "kimi-coding/k2", "stop_reason": "end_turn", "usage": {"input_tokens": 1, "output_tokens": 2}, "files_changed": ["src/b.ts"], "commands_run": ["npm test"], "verify": {"commands": ["npm test"], "passed": true, "notes": ""}}

--- a/tests/fixtures/acn-meta/legacy/c.json
+++ b/tests/fixtures/acn-meta/legacy/c.json
@@ -1,0 +1,1 @@
+{"id": "c", "model": "minimax/MiniMax-M3", "stop_reason": "end_turn", "usage": {"input_tokens": 3, "output_tokens": 4}}

--- a/tests/fixtures/acn-meta/match/a.json
+++ b/tests/fixtures/acn-meta/match/a.json
@@ -1,1 +1,1 @@
-{"id": "a", "requested_model": "anthropic/claude-opus-4-7", "actual_model": "anthropic/claude-opus-4-7", "usage": {"input_tokens": 10, "output_tokens": 20}}
+{"id": "a", "requested_model": "anthropic/claude-opus-4-7", "actual_model": "anthropic/claude-opus-4-7", "stop_reason": "end_turn", "usage": {"input_tokens": 10, "output_tokens": 20}, "files_changed": ["src/a.ts"], "commands_run": ["npm test"], "verify": {"commands": ["npm test"], "passed": true, "notes": ""}}

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# run-all.sh — the whole beastmode gate in one command.
+#
+# The repo's own thesis is that a run is not validated until a gate says so.
+# Until now the gates existed as three separate scripts with no entrypoint, so
+# "all tests pass" meant "whichever ones you remembered to run". This is the
+# entrypoint: CI runs it, and so should you before pushing.
+#
+# Mirrors the verification commands in .planning/ACCEPTANCE.md.
+#
+#   ./tests/run-all.sh          # run everything, print a summary
+#
+# Exit code: 0 all green, 1 any failure.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+# py_compile would otherwise litter __pycache__ into the repo; a test run must
+# leave the working tree exactly as it found it.
+export PYTHONDONTWRITEBYTECODE=1
+
+FAILED=()
+PASSED=()
+
+run_step() {
+  local name="$1"; shift
+  echo
+  echo "=============================================================="
+  echo ">> $name"
+  echo "=============================================================="
+  if "$@"; then
+    PASSED+=("$name")
+  else
+    echo "!! FAILED: $name (exit $?)"
+    FAILED+=("$name")
+  fi
+}
+
+# ---- static checks ----
+syntax_check() {
+  local rc=0
+  # shellcheck disable=SC2044
+  for f in $(find scripts tests -type f \( -name '*.sh' -o -name 'bm' -o -name 'enforce-models' \)); do
+    head -1 "$f" | grep -q 'bash\|sh' || continue
+    bash -n "$f" || rc=1
+  done
+  python3 -m py_compile scripts/acn-report scripts/phase-estimate \
+      scripts/cache-hitrate scripts/lib/acn_meta.py || rc=1
+  return $rc
+}
+
+json_check() {
+  local rc=0
+  for f in schema/*.json scripts/tier-aliases.json; do
+    python3 -m json.tool "$f" >/dev/null || { echo "invalid JSON: $f"; rc=1; }
+  done
+  return $rc
+}
+
+run_step "syntax (bash -n + py_compile)" syntax_check
+run_step "JSON validity (schema/ + tier-aliases)" json_check
+run_step "phase-estimate self-test" python3 scripts/phase-estimate --self-test
+run_step "ACN parity" ./tests/test-acn-parity.sh
+run_step "bm model preflight" ./tests/test-bm-model-check.sh
+run_step "bm thinking passthrough" ./tests/test-bm-thinking.sh
+
+# ---- summary ----
+echo
+echo "=============================================================="
+for name in "${PASSED[@]}"; do
+  echo "  PASS  $name"
+done
+for name in "${FAILED[@]+"${FAILED[@]}"}"; do
+  echo "  FAIL  $name"
+done
+echo "=============================================================="
+if [ "${#FAILED[@]}" -eq 0 ]; then
+  echo "beastmode: ${#PASSED[@]}/${#PASSED[@]} steps green"
+  exit 0
+fi
+echo "beastmode: ${#FAILED[@]} step(s) failed"
+exit 1

--- a/tests/test-acn-parity.sh
+++ b/tests/test-acn-parity.sh
@@ -112,15 +112,12 @@ else
 fi
 
 # ---- (e) enforce-models --check-meta fixture sanity ----
+# Fixtures are committed under tests/fixtures/acn-meta and read, not
+# regenerated. The old version rewrote them into the repo tree on every run,
+# which made the committed copies decorative and let them drift from the
+# schema they are supposed to exemplify.
 echo "check (e): enforce-models --check-meta"
 FIX="$ROOT/tests/fixtures/acn-meta"
-mkdir -p "$FIX/match" "$FIX/drift"
-cat > "$FIX/match/a.json" <<'JSON'
-{"id": "a", "requested_model": "anthropic/claude-opus-4-7", "actual_model": "anthropic/claude-opus-4-7", "usage": {"input_tokens": 10, "output_tokens": 20}}
-JSON
-cat > "$FIX/drift/b.json" <<'JSON'
-{"id": "b", "requested_model": "anthropic/claude-opus-4-7", "actual_model": "kimi-coding/k2", "usage": {"input_tokens": 1, "output_tokens": 2}}
-JSON
 
 set +e
 out_match="$("$ROOT/scripts/enforce-models" --check-meta "$FIX/match" 2>&1)"
@@ -138,6 +135,107 @@ if [ "$rc_drift" = "1" ] && echo "$out_drift" | grep -q "MODEL DRIFT"; then
   pass "enforce-models --check-meta drifting exits 1 with MODEL DRIFT"
 else
   fail "enforce-models --check-meta drift dir: expected exit 1 with 'MODEL DRIFT', got rc=$rc_drift out=$out_drift"
+fi
+
+# ---- (e2) the gate fails closed on unprovable provenance ----
+# Regression for the v2.2 fail-open pair: a legacy {"id","model",...} meta was
+# skipped as "not a meta file we recognise", and an empty run dir returned 0.
+# Both reported a clean batch while proving nothing about which model ran.
+echo "check (e2): provenance gate fails closed"
+run_gate() { set +e; GATE_OUT="$("$@" 2>&1)"; GATE_RC=$?; set -e; }
+
+run_gate "$ROOT/scripts/enforce-models" --check-meta "$FIX/legacy"
+if [ "$GATE_RC" = "1" ] && echo "$GATE_OUT" | grep -q "UNVERIFIABLE"; then
+  pass "legacy model-only meta is UNVERIFIABLE, exit 1"
+else
+  fail "legacy meta: expected exit 1 with UNVERIFIABLE, got rc=$GATE_RC out=$GATE_OUT"
+fi
+
+run_gate "$ROOT/scripts/enforce-models" --check-meta "$FIX/empty"
+if [ "$GATE_RC" = "1" ] && echo "$GATE_OUT" | grep -q "UNVERIFIABLE"; then
+  pass "empty run dir is UNVERIFIABLE, exit 1"
+else
+  fail "empty dir: expected exit 1 with UNVERIFIABLE, got rc=$GATE_RC out=$GATE_OUT"
+fi
+
+run_gate "$ROOT/scripts/enforce-models" --check-meta "$FIX/empty" --allow-empty
+if [ "$GATE_RC" = "0" ]; then
+  pass "empty run dir with --allow-empty exits 0"
+else
+  fail "empty dir --allow-empty: expected exit 0, got rc=$GATE_RC out=$GATE_OUT"
+fi
+
+printf '%s' '{"id": "half", "requested_model": "anthropic/claude-opus-4-7"' > "$TMP/meta.json"
+run_gate "$ROOT/scripts/enforce-models" --check-meta "$TMP"
+if [ "$GATE_RC" = "1" ] && echo "$GATE_OUT" | grep -q "UNVERIFIABLE"; then
+  pass "truncated meta is UNVERIFIABLE, exit 1"
+else
+  fail "truncated meta: expected exit 1 with UNVERIFIABLE, got rc=$GATE_RC out=$GATE_OUT"
+fi
+rm -f "$TMP/meta.json"
+
+# ---- (e3) enforce-models and acn-report agree on every fixture ----
+# They used to be two implementations of one contract with different file
+# discovery, so a child could pass one tool and fail the other.
+echo "check (e3): enforce-models and acn-report agree"
+AGREE=1
+for case_dir in match drift legacy empty; do
+  set +e
+  "$ROOT/scripts/enforce-models" --check-meta "$FIX/$case_dir" >/dev/null 2>&1
+  rc_enforce=$?
+  "$ROOT/scripts/acn-report" "$FIX/$case_dir" >/dev/null 2>&1
+  rc_report=$?
+  set -e
+  if [ "$rc_enforce" != "$rc_report" ]; then
+    fail "$case_dir: enforce-models exit $rc_enforce but acn-report exit $rc_report"
+    AGREE=0
+  fi
+done
+[ "$AGREE" = "1" ] && pass "enforce-models and acn-report agree on all fixtures"
+
+# ---- (e4) prose meta.json fields match the schema ----
+# references/acn-contract.md documents the meta shape in prose; the schema
+# declares it in JSON. Neither is allowed to drift from the other.
+echo "check (e4): acn-contract.md meta fields match schema"
+python3 - "$ROOT" <<'PY' && pass "acn-contract.md meta fields match schema" || fail "acn-contract.md meta fields drifted from schema/acn-contract.json"
+import json, re, sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+schema = json.loads((root / "schema" / "acn-contract.json").read_text())
+declared = set(schema["meta_json_required_fields"])
+
+doc = (root / "references" / "acn-contract.md").read_text()
+block = re.search(r"## Per-child meta\.json.*?```\n(.*?)```", doc, re.S)
+if not block:
+    print("could not find the meta.json block in references/acn-contract.md", file=sys.stderr)
+    sys.exit(1)
+documented = {
+    line.split()[0]
+    for line in block.group(1).splitlines()
+    if line.strip() and not line.startswith(" ")
+}
+
+if documented != declared:
+    print(f"only in schema: {sorted(declared - documented)}", file=sys.stderr)
+    print(f"only in doc:    {sorted(documented - declared)}", file=sys.stderr)
+    sys.exit(1)
+PY
+
+# ---- (e5) no spec still prescribes the pre-v2.3 merged-model meta shape ----
+# Scoped to the surfaces that *specify* the contract. .learnings/ and
+# .planning/ are records of what happened, and a record of this defect has to
+# be able to quote the broken shape verbatim to be worth reading.
+echo "check (e5): no legacy meta shape in specs"
+LEGACY_SHAPE='"id", *"model"'
+legacy_hits="$(grep -rn "$LEGACY_SHAPE" --include='*.md' \
+  "$ROOT/SKILL.md" "$ROOT/README.md" "$ROOT/references" "$ROOT/adapters" "$ROOT/pi" \
+  2>/dev/null || true)"
+if [ -n "$legacy_hits" ]; then
+  echo "$legacy_hits" >&2
+  fail "a spec still prescribes the merged-model meta shape (gate cannot compare it)"
+else
+  pass "no spec prescribes the merged-model meta shape"
 fi
 
 # ---- (f) adapter SKILL.md vocabulary ----
@@ -175,6 +273,33 @@ else
     fail "scripts/bm --harness bogus expected exit 2, got $rc; output: $out"
   fi
 fi
+
+# ---- (h) adapter version cross-refs track SKILL.md ----
+# Each adapter names the canonical skill version it implements. Nothing kept
+# those in sync with SKILL.md's frontmatter, so a bump silently left three
+# adapters claiming an older contract.
+echo "check (h): adapter version cross-refs match SKILL.md"
+python3 - "$ROOT" <<'PY' && pass "adapter version cross-refs match SKILL.md" || fail "adapter version cross-refs drifted from SKILL.md frontmatter"
+import re, sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+skill = (root / "SKILL.md").read_text()
+match = re.search(r"^version:\s*(\S+)\s*$", skill, re.M)
+if not match:
+    print("no version in SKILL.md frontmatter", file=sys.stderr)
+    sys.exit(1)
+canonical = match.group(1)
+
+bad = []
+for adapter in sorted((root / "adapters").glob("*/SKILL.md")):
+    for ref in re.findall(r"`beastmode`[^\n]*?\(v(\d+\.\d+\.\d+)\)", adapter.read_text()):
+        if ref != canonical:
+            bad.append(f"{adapter.relative_to(root)} claims v{ref}, SKILL.md is v{canonical}")
+for line in bad:
+    print(line, file=sys.stderr)
+sys.exit(1 if bad else 0)
+PY
 
 # ---- summary ----
 echo

--- a/tests/test-acn-parity.sh
+++ b/tests/test-acn-parity.sh
@@ -174,6 +174,70 @@ else
 fi
 rm -f "$TMP/meta.json"
 
+# A half-written child alongside a good one. The first cut of the gate keyed
+# candidate detection on provenance fields, so a child that died before
+# writing them was not recognised as a child at all — it vanished from the
+# report and the good sibling carried the batch to exit 0.
+SIB="$TMP/siblings"; mkdir -p "$SIB"
+cp "$FIX/match/a.json" "$SIB/a.json"
+printf '%s\n' '{"id": "lost", "usage": {"input_tokens": 900, "output_tokens": 40}}' > "$SIB/lost.json"
+run_gate "$ROOT/scripts/enforce-models" --check-meta "$SIB"
+if [ "$GATE_RC" = "1" ] && echo "$GATE_OUT" | grep -q "lost"; then
+  pass "half-written sibling is UNVERIFIABLE despite a valid sibling"
+else
+  fail "half-written sibling: expected exit 1 naming 'lost', got rc=$GATE_RC out=$GATE_OUT"
+fi
+
+# ...and it must still appear as a row in the report, not just in the verdict.
+run_gate "$ROOT/scripts/acn-report" "$SIB"
+if echo "$GATE_OUT" | grep -q "lost"; then
+  pass "acn-report lists the half-written child as a row"
+else
+  fail "acn-report omitted the half-written child: $GATE_OUT"
+fi
+
+# Provider config that merely mentions a model must NOT be read as a child —
+# false-failing it would train people to pass --allow-empty everywhere.
+CFG="$TMP/withcfg"; mkdir -p "$CFG"
+cp "$FIX/match/a.json" "$CFG/a.json"
+printf '%s\n' '{"model": "minimax/MiniMax-M3", "provider": "minimax"}' > "$CFG/config.json"
+run_gate "$ROOT/scripts/enforce-models" --check-meta "$CFG"
+if [ "$GATE_RC" = "0" ]; then
+  pass "provider config is not mistaken for a child record"
+else
+  fail "provider config false-failed the gate: rc=$GATE_RC out=$GATE_OUT"
+fi
+
+# A child that wrote nothing at all leaves no file to scan, so only the
+# batch's own id list can catch it.
+run_gate "$ROOT/scripts/enforce-models" --check-meta "$FIX/match" --expect a,ghost
+if [ "$GATE_RC" = "1" ] && echo "$GATE_OUT" | grep -q "ghost"; then
+  pass "--expect catches a child that wrote no meta"
+else
+  fail "--expect: expected exit 1 naming 'ghost', got rc=$GATE_RC out=$GATE_OUT"
+fi
+
+run_gate "$ROOT/scripts/enforce-models" --check-meta "$FIX/match" --expect a
+if [ "$GATE_RC" = "0" ]; then
+  pass "--expect passes when every expected child reported"
+else
+  fail "--expect all-present: expected exit 0, got rc=$GATE_RC out=$GATE_OUT"
+fi
+
+# --expect also reads the batch file directly, since schema/acn-contract.json
+# already requires tasks[].id — the manifest is a file the contract guarantees.
+cat > "$TMP/batch.json" <<'JSON'
+{"autonomy": "medium", "concurrency": 3,
+ "tasks": [{"id": "a", "goal": "g", "allowed_paths": ["src"], "verify_cmds": ["true"]},
+           {"id": "ghost", "goal": "g", "allowed_paths": ["src"], "verify_cmds": ["true"]}]}
+JSON
+run_gate "$ROOT/scripts/enforce-models" --check-meta "$FIX/match" --expect "$TMP/batch.json"
+if [ "$GATE_RC" = "1" ] && echo "$GATE_OUT" | grep -q "ghost"; then
+  pass "--expect reads child ids from a batch file"
+else
+  fail "--expect batch file: expected exit 1 naming 'ghost', got rc=$GATE_RC out=$GATE_OUT"
+fi
+
 # ---- (e3) enforce-models and acn-report agree on every fixture ----
 # They used to be two implementations of one contract with different file
 # discovery, so a child could pass one tool and fail the other.


### PR DESCRIPTION
Architecture review of beastmode v2.2, plus fixes. All 6 gate steps green (`./tests/run-all.sh`), ACN parity 19 PASS / 0 FAIL / 1 SKIP (pi not on this host).

## The headline finding

The MODEL DRIFT gate passed batches it had proven nothing about — and the way to trigger it was to follow the repo's own documentation.

- `enforce-models --check-meta` skipped any meta lacking `requested_model` / `actual_model` as *"not a meta file we recognise"*.
- `acn-report` rendered the same meta as `requested: unavailable -> actual: unavailable` — equal, therefore `Drift: none`.
- `references/autonomy-levels.md` and `pi/SKILL.md` both specified `{"id","model","stop_reason","usage"}` — the one shape neither tool could evaluate.

So a pi worker (the default harness) following the documented contract passed the gate on a model nobody could name. An empty run directory also exited 0.

Reproduced before the fix, against a directory holding one legacy-shape meta:

```
$ cat rundir/child.json
{"id":"legacy","model":"minimax/MiniMax-M3","stop_reason":"end_turn","usage":{"input_tokens":5,"output_tokens":5}}

$ enforce-models --check-meta rundir
exit=0

$ acn-report rundir
Models: requested unavailable -> actual unavailable
Drift: none
exit=0
```

Both now exit 1 with `UNVERIFIABLE`, as does an empty run directory.

The rule was already written down — `adapters/codex/SKILL.md` was the only surface that named the unverifiable case — it just wasn't implemented anywhere. Every fail-open here was a two-valued gate (drift / no-drift) meeting a three-valued reality, with "unprovable" landing in the pass bucket by default.

## Changes

**Gate** — `scripts/lib/acn_meta.py` is now the single implementation, returning `ok` / `drift` / `unverifiable`, with `unverifiable` failing per ACN shared rule 2. Both `enforce-models --check-meta` and `acn-report` call it, so they can no longer disagree about whether a batch is validated (they previously used different globs and different comparisons, with nothing asserting parity). It reads `meta_json_required_fields` out of `schema/acn-contract.json`, making the schema load-bearing rather than decorative — it was called "the machine source of truth" in four documents while no code read it. `--allow-empty` turns "this batch had no children" into an assertion instead of a default.

**Contract** — `schema/acn-contract.json` v1.1 gains `unverifiable_policy`, `gate_verdicts`, `gate_implementation`, and a fifth hard rule. `autonomy-levels.md` and `pi/SKILL.md` now specify the schema shape; the hermes and claude-code adapters gain the unverifiable rule codex already had.

**`scripts/bm`** — three defects found while tracing seat resolution:

| Defect | Effect |
|---|---|
| `--models "$FRONTIER,$ECONOMY"` | Leading comma whenever `--economy` was passed without `--frontier` |
| `--on` dispatch | Raw goal spliced into `bm '$GOAL' ...` — an apostrophe closed the quote and the remainder ran as remote shell words |
| `--harness claude` | Passed the resolved `provider/model` to `claude --model`, which wants a bare id; `enforce-models` warned on every correct invocation |

The ssh fix uses POSIX single-quoting rather than `printf %q`, since the remote login shell isn't guaranteed to be bash.

**Tests** — `tests/run-all.sh` is the entrypoint (there wasn't one; three scripts, nothing running them together). `.github/workflows/tests.yml` runs it and asserts the suite leaves the working tree clean — `test-acn-parity.sh` used to rewrite its own fixtures on every run, which made the committed copies decorative and let them drift from the schema. New parity checks cover both fail-open cases, enforce-models/acn-report agreement, prose-vs-schema meta fields, and adapter version cross-refs. Each was negative-tested by deliberately breaking the invariant and confirming a FAIL.

## Verification

```
$ ./tests/run-all.sh
  PASS  syntax (bash -n + py_compile)
  PASS  JSON validity (schema/ + tier-aliases)
  PASS  phase-estimate self-test
  PASS  ACN parity            # 19 PASS / 0 FAIL / 1 SKIP
  PASS  bm model preflight
  PASS  bm thinking passthrough
beastmode: 6/6 steps green
```

## Flagged, not changed

Recorded in `.learnings/BEASTMODE.md` rather than fixed here — each is a judgment call that belongs to you:

- `opus5` resolves to `claude-opus-4-8` and `sonnet` to `claude-sonnet-4-6` in `scripts/tier-aliases.json`. Left alone since the file states it was verified against `pi --list-models` on oracle-1 / maeve-u1, but the alias names are misleading if newer models are available on those hosts.
- `bm`'s documented exit-code contract (`0 = goal_complete`, `1 = goal_blocked`) isn't implemented — `bm` `exec`s the harness, so callers get the harness's exit code with no mapping.
- Autonomy to harness flag mapping is only symmetric at `high`. `low` maps to `--approve` on pi and to nothing on hermes/claude/codex, so "identical across harnesses by construction" currently holds for the prompt strings, not the enforcement flags.
- `bm --watcher ALIAS` resolves and preflights the watcher seat but never passes it to any harness — it reaches the run as prompt text only.