### PR TITLE
docs(planning): roadmap for beastmode as a first-class LangGraph layer (v2.4.0)

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -3,7 +3,7 @@
 | Effort | Status | Docs |
 |---|---|---|
 | ACN Unification (v2.2.0) | **shipped** — see below; hardened in v2.3.0 | this file, `ACCEPTANCE.md` |
-| Beastmode on LangGraph (v2.4.0) | **planning** — blocked on `langgraph/OPEN-QUESTIONS.md` Q1–Q3 | `langgraph/ROADMAP.md`, `langgraph/REQUIREMENTS.md`, `langgraph/ACCEPTANCE.md`, `langgraph/OPEN-QUESTIONS.md` |
+| Beastmode on LangGraph (v2.4.0) | **planning** — Q1/Q2/Q3/Q5 decided; P0 spikes ready to start | `langgraph/ROADMAP.md`, `langgraph/REQUIREMENTS.md`, `langgraph/ACCEPTANCE.md`, `langgraph/OPEN-QUESTIONS.md` |
 | CrewAI binding | **deferred** — gated on the LangGraph effort's P7 | `langgraph/ROADMAP.md` §P8 |
 
 ---

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,3 +1,13 @@
+# Beastmode roadmap index
+
+| Effort | Status | Docs |
+|---|---|---|
+| ACN Unification (v2.2.0) | **shipped** — see below; hardened in v2.3.0 | this file, `ACCEPTANCE.md` |
+| Beastmode on LangGraph (v2.4.0) | **planning** — blocked on `langgraph/OPEN-QUESTIONS.md` Q1–Q3 | `langgraph/ROADMAP.md`, `langgraph/REQUIREMENTS.md`, `langgraph/ACCEPTANCE.md`, `langgraph/OPEN-QUESTIONS.md` |
+| CrewAI binding | **deferred** — gated on the LangGraph effort's P7 | `langgraph/ROADMAP.md` §P8 |
+
+---
+
 # ROADMAP — Beastmode ACN Unification (v2.2.0)
 
 Branch: `feat/acn-unification` (worktree `../.bm-worktrees/acn`). Merges to `main` locally; no push to origin without explicit ship-it.

--- a/.planning/langgraph/ACCEPTANCE.md
+++ b/.planning/langgraph/ACCEPTANCE.md
@@ -1,0 +1,100 @@
+# Acceptance Contract — Beastmode on LangGraph (v2.4.0)
+
+This contract covers **P0–P6** of `ROADMAP.md`. P7 (the `forever` graph) and P8
+(CrewAI) get their own contracts when they're unblocked.
+
+Written per `SKILL.md` §Step 1. Not authorized to start until `OPEN-QUESTIONS.md`
+Q1–Q3 are answered — the answers change P3 and P4.
+
+---
+
+**Goal:** beastmode ships a `pip`-installable Python distribution that gives
+LangGraph users the beastmode loop as ready-to-use `StateGraph`s — tier routing,
+acceptance contracts, provenance/drift gates, ACN parallel fan-out, autonomy
+gating, per-phase usage reporting, self-improvement checkpoint — with a
+framework-neutral `beastmode.core` that a CrewAI binding can later reuse.
+
+**Non-goals:** CrewAI implementation. The `forever` graph. Hosted deployment or
+LangGraph Platform. Rewriting `scripts/bm` in Python. Replacing or modifying the
+hermes / pi / claude / codex adapters. Any change to the meaning of
+`schema/*.json`. Self-modifying graph topology. Pushing to origin without an
+explicit ship-it.
+
+**User-visible acceptance:**
+
+- A LangGraph user runs `pip install beastmode[langgraph]`, imports one builder,
+  compiles a graph, and gets a beastmode run with gates that block below `high`
+  autonomy — without reading `SKILL.md`.
+- `bm "<goal>" --harness langgraph --frontier <alias> --economy <alias>
+  --watcher <alias> --autonomy low|medium|high` preflights seats and runs with
+  the same phase-report / gate / drift prompts as every other harness.
+- A run killed mid-phase resumes from its checkpoint on the same `thread_id`
+  and completes.
+- `graph.get_graph().draw_mermaid()` renders the loop as a living flowchart,
+  committed to `references/langgraph-pipeline.md`.
+- A beastmode user who never touches LangGraph installs nothing and sees no
+  behavior change.
+
+**Invariants that must hold (each negative-tested by deliberately breaking it):**
+
+1. `schema/*.json` remains the single source of truth — no field list exists in
+   two places. Python types are read from the JSON at import.
+2. `scripts/lib/acn_meta.py` remains the only implementation of the
+   `ok` / `drift` / `unverifiable` verdict. The graph calls it.
+3. `unverifiable` fails. LangGraph retry, error handling, and aggregation
+   cannot convert it into a pass or a silent skip.
+4. A passing child never carries a failing sibling. A child that wrote no meta
+   at all is caught via `--expect`.
+5. The main working tree is unmodified for the duration of any run; executors
+   work in worktrees and never commit, push, or read secrets.
+6. Gates block below `high` autonomy; `MODEL DRIFT` surfaces at every level.
+7. `beastmode.core` imports no agent framework — proven in CI, not by review.
+
+**Files/areas likely touched:** `python/` (new), `scripts/bm`,
+`scripts/enforce-models`, `scripts/lib/acn_meta.py` (possible relocation — Q10),
+`adapters/langgraph/` (new), `references/`, `tests/test-acn-parity.sh`,
+`.github/workflows/tests.yml`, `SKILL.md`, `README.md`, `.planning/`.
+
+**Verification commands:**
+
+```bash
+./tests/run-all.sh                    # must pass with NO Python packages installed
+pytest python/tests                   # new lane, package installed
+lint-imports                          # beastmode.core has zero framework imports
+bash tests/test-acn-parity.sh         # extended: Python ChildMeta == schema fields
+bash tests/test-bm-model-check.sh     # regression: --harness bogus still exits 2
+bash -n scripts/bm scripts/enforce-models scripts/acn-report scripts/lib/prompts.sh
+python3 -m json.tool schema/*.json scripts/tier-aliases.json
+python -m build python/              # wheel builds; imports with no provider SDKs
+git status --porcelain               # empty after the full suite (CI already asserts this)
+```
+
+**Manual QA:**
+
+- Read `adapters/langgraph/SKILL.md` against the other four adapters for
+  vocabulary drift (`low`/`medium`/`high`, `MODEL DRIFT`, "no watcher no
+  validated", "gates are blocking below high").
+- Confirm `SKILL.md` frontmatter version is `2.4.0` and every adapter's
+  canonical cross-reference agrees.
+- Run one real goal end-to-end at `--autonomy medium`; confirm it stops at each
+  gate and that the phase report shows requested vs actual model per child.
+- Confirm the mermaid render matches the actual node/edge set.
+
+**Escalation triggers:**
+
+- P0.1 finds that `actual_model` is unprovable for a provider we intend to
+  support with direct-call nodes → stop, surface, re-decide Q2 before P2.
+- Any change to `scripts/lib/acn_meta.py`'s verdict logic — that file is the
+  gate; edits to it are frontier-review-mandatory, not economy work.
+- Any proposal to add a `best-effort` or `warn-only` provenance mode.
+- Adding a dependency to the bash lane, or making `tests/run-all.sh` require an
+  install.
+- Anything that would make `schema/*.json` decorative again.
+- Deleting files; touching `pi/`; pushing to origin.
+
+**Watcher requirement:** cross-family adversarial review is **mandatory on P2
+and P4** and blocking for merge. `.learnings/BEASTMODE.md` records the reason: the
+last fail-open in this exact gate survived 19 passing checks and green CI, and
+was caught only by a cross-family reviewer. No watcher, no `validated`.
+
+**Self-improvement log path:** `.learnings/BEASTMODE.md`

--- a/.planning/langgraph/ACCEPTANCE.md
+++ b/.planning/langgraph/ACCEPTANCE.md
@@ -1,6 +1,6 @@
 # Acceptance Contract — Beastmode on LangGraph (v2.4.0)
 
-This contract covers **P0–P6** of `ROADMAP.md`. P7 (the `forever` graph) and P8
+This contract covers **P0–P7** of `ROADMAP.md`. P8 (the `forever` graph) and P9
 (CrewAI) get their own contracts when they're unblocked.
 
 Written per `SKILL.md` §Step 1. `OPEN-QUESTIONS.md` Q1, Q2, Q3 and Q5 were
@@ -37,8 +37,6 @@ explicit ship-it.
   and completes.
 - `graph.get_graph().draw_mermaid()` renders the loop as a living flowchart,
   committed to `references/langgraph-pipeline.md`.
-- A beastmode user who never touches LangGraph installs nothing and sees no
-  behavior change.
 
 **Invariants that must hold (each negative-tested by deliberately breaking it):**
 

--- a/.planning/langgraph/ACCEPTANCE.md
+++ b/.planning/langgraph/ACCEPTANCE.md
@@ -3,8 +3,9 @@
 This contract covers **P0–P6** of `ROADMAP.md`. P7 (the `forever` graph) and P8
 (CrewAI) get their own contracts when they're unblocked.
 
-Written per `SKILL.md` §Step 1. Not authorized to start until `OPEN-QUESTIONS.md`
-Q1–Q3 are answered — the answers change P3 and P4.
+Written per `SKILL.md` §Step 1. `OPEN-QUESTIONS.md` Q1, Q2, Q3 and Q5 were
+answered 2026-08-03 and are folded in below; Q4 and Q6–Q10 remain open but do
+not block P0.
 
 ---
 
@@ -20,14 +21,18 @@ hermes / pi / claude / codex adapters. Any change to the meaning of
 `schema/*.json`. Self-modifying graph topology. Pushing to origin without an
 explicit ship-it.
 
-**User-visible acceptance:**
+**User-visible acceptance** (in priority order — the first decides ties):
 
+- **A beastmode user who never installs the package sees no change at all.**
+  Every existing `bm` invocation behaves identically to `main`, and
+  `./tests/run-all.sh` passes with no Python packages present.
+- `bm "<goal>" --harness langgraph --frontier <alias> --economy <alias>
+  --watcher <alias> --autonomy low|medium|high` preflights seats and runs with
+  the same phase-report / gate / drift prompts as every other harness — and
+  exits 2 with an install hint, never a traceback, when the package is absent.
 - A LangGraph user runs `pip install beastmode[langgraph]`, imports one builder,
   compiles a graph, and gets a beastmode run with gates that block below `high`
   autonomy — without reading `SKILL.md`.
-- `bm "<goal>" --harness langgraph --frontier <alias> --economy <alias>
-  --watcher <alias> --autonomy low|medium|high` preflights seats and runs with
-  the same phase-report / gate / drift prompts as every other harness.
 - A run killed mid-phase resumes from its checkpoint on the same `thread_id`
   and completes.
 - `graph.get_graph().draw_mermaid()` renders the loop as a living flowchart,
@@ -37,6 +42,11 @@ explicit ship-it.
 
 **Invariants that must hold (each negative-tested by deliberately breaking it):**
 
+0. **LangGraph is strictly additive.** `./tests/run-all.sh` passes with zero
+   Python packages installed; no bash script, test, schema, doc, or adapter
+   acquires a hard Python dependency; every pre-existing `bm` invocation behaves
+   identically to `main`. This is checked on every phase, and it outranks every
+   other item on this list.
 1. `schema/*.json` remains the single source of truth — no field list exists in
    two places. Python types are read from the JSON at import.
 2. `scripts/lib/acn_meta.py` remains the only implementation of the
@@ -45,8 +55,10 @@ explicit ship-it.
    cannot convert it into a pass or a silent skip.
 4. A passing child never carries a failing sibling. A child that wrote no meta
    at all is caught via `--expect`.
-5. The main working tree is unmodified for the duration of any run; executors
-   work in worktrees and never commit, push, or read secrets.
+5. The main working tree is unmodified for the duration of any run. Per Q2,
+   judgment seats (director / watcher / validator) may call chat models
+   directly, but **every seat that writes files is a subprocess** in its own
+   worktree, and never commits, pushes, or reads secrets.
 6. Gates block below `high` autonomy; `MODEL DRIFT` surfaces at every level.
 7. `beastmode.core` imports no agent framework — proven in CI, not by review.
 
@@ -82,8 +94,12 @@ git status --porcelain               # empty after the full suite (CI already as
 
 **Escalation triggers:**
 
-- P0.1 finds that `actual_model` is unprovable for a provider we intend to
-  support with direct-call nodes → stop, surface, re-decide Q2 before P2.
+- P0.1 finds that `actual_model` is unprovable for a frontier provider we intend
+  to run as a direct-call judgment seat → demote that provider to a subprocess
+  seat; if no frontier provider proves its model, stop and re-decide Q2 before
+  P2 designs around it.
+- Any proposal to add a hard Python dependency to the bash lane, or to make an
+  existing `bm` flag behave differently — invariant 0 is merge-blocking.
 - Any change to `scripts/lib/acn_meta.py`'s verdict logic — that file is the
   gate; edits to it are frontier-review-mandatory, not economy work.
 - Any proposal to add a `best-effort` or `warn-only` provenance mode.

--- a/.planning/langgraph/OPEN-QUESTIONS.md
+++ b/.planning/langgraph/OPEN-QUESTIONS.md
@@ -1,0 +1,187 @@
+# Open questions — Beastmode on LangGraph
+
+Q1–Q3 change the phase order in `ROADMAP.md` and should be answered before P1
+starts. Q4–Q10 can be answered during P0/P1. Each has a recommendation, so
+silence is not a blocker — but a different answer means different phases.
+
+---
+
+## Q1 — What is the deliverable, exactly? (**blocks P1**)
+
+Three different products hide behind "enable LangGraph":
+
+- **A.** `pip install beastmode-langgraph` — a package for *LangGraph users*.
+  They never run `bm`. Highest adoption ceiling; largest new surface (packaging,
+  releases, docs for an audience that has never heard of beastmode).
+- **B.** `bm --harness langgraph` — a fifth harness for *beastmode users*.
+  Smallest change; near-zero adoption value, because it serves people who are
+  already here.
+- **C.** Both — the package is the implementation, `bm --harness langgraph`
+  is a thin caller. One artifact, two audiences.
+
+**Recommendation: C.** It costs almost nothing over A (the `bm` flag is ~20
+lines) and it keeps the package honest: if the package can't run a real
+beastmode goal from `bm`, it isn't finished. The roadmap is written for C —
+package in P1–P4, `bm` flag in P5.
+
+---
+
+## Q2 — Do LangGraph nodes call models, or drive subprocesses? (**blocks P3/P4**)
+
+This is the single biggest architectural call, and it decides whether hard
+rule 1 survives.
+
+- **A. Nodes call chat models directly.** Beastmode becomes a full agent
+  runtime. Clean LangGraph idiom, best LangSmith traces. But nodes run in the
+  orchestrator's process with the orchestrator's credentials — "workers never
+  commit/push", "never access secrets", "stay in `allowed_paths`" become prose
+  again, and drift detection depends entirely on provider metadata (risk 5.1).
+- **B. Nodes spawn the existing coding agents** (`pi`, `claude -p`,
+  `codex exec`, `delegate_task`) as subprocesses in `git worktree`s. LangGraph
+  replaces `bm`'s *control flow*, not the executor. Every existing guarantee
+  survives untouched because the executor is unchanged. Beastmode becomes a
+  harness-of-harnesses.
+- **C. Both** — frontier/judgment nodes call models directly (they only read and
+  decide), executor nodes are subprocesses (they write files).
+
+**Recommendation: C, with B as the fallback if P0.1 says provenance is
+unprovable.** The seats already split this way: directors and watchers produce
+*judgments*, executors produce *diffs*. Only the second needs isolation. And it
+gives the honest product story — "beastmode orchestrates your coding agent"
+rather than "beastmode is another coding agent".
+
+---
+
+## Q3 — Which graph ships first? (**blocks P3 vs P7 ordering**)
+
+Your two messages describe different graphs:
+
+- **A. The pipeline** — the current eight-step loop as a terminating DAG with
+  `interrupt()` gates. A faithful port. Low risk; proves every invariant
+  survives; ships something LangGraph users can use immediately.
+- **B. The evolver** ("ForwardEditor" style) — PRD maintainer, priority curator,
+  brainstormers, implementer, reviewer, context re-packer, cleanup, user-redirect
+  edge. Cyclic, non-terminating, runs for days. This is the *new* capability and
+  the thing the original post is actually about.
+
+**Recommendation: A first, B as P7.** Not out of caution — B genuinely needs
+things A builds: the provenance gate in state, ACN via `Send`, worktree
+executors, checkpointing. Building B first means building all of A anyway, with
+no gate to catch mistakes. But if the *point* is the evolver and the pipeline is
+uninteresting to you, say so — the roadmap collapses to a much smaller P3 and
+P7 moves up.
+
+---
+
+## Q4 — One distribution or two? (**P1**)
+
+`beastmode-core` + `beastmode-langgraph` as separate PyPI packages, or one
+`beastmode` package with `[langgraph]` / `[crewai]` extras?
+
+**Recommendation: one package, extras.** Two packages means two release
+cadences and a version-compatibility matrix for a project that has never
+released a Python package at all. The `core` boundary is enforced by
+import-linter either way — that's what actually protects the CrewAI future, not
+the packaging split.
+
+---
+
+## Q5 — May the graph rewrite itself?
+
+Your framing includes "self-improvement loop that rewrites the orchestration
+itself" and "a graph agents can walk, branch, or rewrite". Today that is
+explicitly forbidden: *"The self-improvement loop writes notes only during a
+beastmode run. Any lasting change to agent behavior belongs in a separate
+user-approved maintenance task."*
+
+Options: (a) keep the rule — the graph proposes topology diffs, a human
+approves; (b) allow topology mutation inside a run at `--autonomy high` only;
+(c) drop the rule.
+
+**Recommendation: (a).** This rule was earned. Note that (a) still gets you most
+of what you want, because in LangGraph the topology *is* data — a node can emit
+a proposed graph diff, render it as mermaid, and open it as a PR. That is a
+better artifact than a silent self-edit, and it's reviewable.
+
+---
+
+## Q6 — What happens on a provider that can't prove `actual_model`?
+
+If P0.1 finds a provider that echoes the alias rather than the resolved model,
+every direct-call child on that lane is `unverifiable` — a red gate, forever.
+
+Options: (a) document it unsupported for direct-call nodes (subprocess
+executors still work, since the harness writes its own meta); (b) add a
+`provenance: best-effort` mode that downgrades those to a warning; (c) block
+the provider entirely.
+
+**Recommendation: (a).** (b) is exactly the fail-open the v2.3 review closed —
+"we could not tell which model ran this" is not a pass, and a `best-effort` flag
+is how that comes back.
+
+---
+
+## Q7 — Does this ship to PyPI under your name, and when?
+
+Adoption depends on a real, installable, discoverable package. That means a
+PyPI namespace, a release process, a support surface, and issues from people
+who don't use any of your harnesses.
+
+Is `beastmode-langgraph` the name (is it free on PyPI)? Publish at P6, or hold
+until P7 makes the evolver story real? **Recommendation: publish at P6.** The
+pipeline alone is useful, and shipping early gets the API critiqued before P7
+builds on it.
+
+---
+
+## Q8 — Is LangSmith allowed to be the observability story?
+
+It's the natural fit and the thing LangGraph users already have. It is also
+hosted, which means run metadata leaves the machine.
+
+**Recommendation: optional, off by default,** with `acn-report` as the offline
+path. If a beastmode run's phase report requires a SaaS account, cost discipline
+and provenance stop being self-contained.
+
+---
+
+## Q9 — What's the budget ceiling for a `forever` run?
+
+P7 has no natural termination. Beastmode has autonomy levels but no spend cap
+primitive, and LangGraph has no equivalent of `pi-loop-police`'s anti-spin
+breaker.
+
+Needed before P7: a hard token/dollar ceiling per thread, a stall detector
+(N cycles with no diff), and what happens at the ceiling — `interrupt()` and
+wait, or halt.
+
+---
+
+## Q10 — Does `acn_meta.py` move?
+
+A `pip`-installed package can't reach `scripts/lib/acn_meta.py` in a repo that
+may not be checked out. Either it moves into `beastmode/core/` and the bash
+scripts import it from there, or the package vendors a copy.
+
+**Recommendation: move it.** Vendoring is how "one contract, two
+implementations" comes back. One file, one location, both callers import it.
+
+---
+
+## Not questions, but things worth knowing before you commit
+
+- **This adds a dependency tree to a repo that has none.** `langgraph` pulls
+  `langchain-core` and its transitive set. The bash lane must stay
+  install-free — that constraint is in the roadmap exits, but it's worth
+  deciding you actually want the split rather than discovering it in P1.
+- **Checkpoints are not durable execution.** The checkpointer saves state; it
+  does not detect that your process died. "Runs for days while you ignore it"
+  needs a supervisor outside LangGraph. Any claim made before that exists is
+  false.
+- **CrewAI Flows shares no API shape with `StateGraph`.** The only thing that
+  transfers is `beastmode.core`. That's why the core split is P1 and not a
+  refactor later — it's the entire cost of "in a perfect world it works with
+  CrewAI too", paid once and up front.
+- **Prompt-cache lane grouping may not survive `Send`.** It's a real cost line
+  in `SKILL.md` and LangGraph has no primitive for it. P0.3 measures it rather
+  than guessing.

--- a/.planning/langgraph/OPEN-QUESTIONS.md
+++ b/.planning/langgraph/OPEN-QUESTIONS.md
@@ -220,6 +220,91 @@ hosted, which means run metadata leaves the machine.
 path. If a beastmode run's phase report requires a SaaS account, cost discipline
 and provenance stop being self-contained.
 
+### How onboarding actually works — scoped design
+
+Still open as a *policy* question (do we bless it?), but the *mechanics* are
+settled enough to scope, because two of them are non-obvious and one is a trap.
+
+**1. The graph traces itself for free.** Three env vars and every node becomes a
+span:
+
+```bash
+export LANGSMITH_TRACING=true
+export LANGSMITH_API_KEY=...
+export LANGSMITH_PROJECT=beastmode          # optional, defaults to "default"
+export LANGSMITH_ENDPOINT=https://...       # self-hosted only
+```
+
+No code change. `graph.ainvoke()` produces a trace tree with one run per node,
+nested correctly, with token usage on every model call.
+
+**2. The subprocess executors are a hole, and they're where the run actually
+lives.** Per Q2, executor seats are `pi` / `claude -p` / `codex exec`
+subprocesses. LangSmith sees a node that took eight minutes and returned a
+dict — the implementation work, the tool calls, and the majority of the run's
+tokens and wall-clock are all invisible. Tracing that shows only the cheap half
+of a cost-discipline framework is worse than no tracing, because it looks
+complete.
+
+LangSmith supports distributed tracing via a `langsmith-trace` header and a
+`tracing_context` manager, but that only helps when the child process is itself
+LangSmith-aware. `pi`, `codex exec`, and `claude -p` are not.
+
+**The fix falls out of something beastmode already does.** Every child already
+writes a `meta.json` with `usage`, `requested_model`, `actual_model`,
+`stop_reason`, `files_changed`, `commands_run`, and `verify`. **That record is a
+span.** The executor node synthesizes a LangSmith child run from it after the
+subprocess exits, attached to the node's own run as parent (the SDK's `parent`
+accepts a `RunTree` or a dotted-order string). No new artifact, no new
+collection, no change to the worker contract — the provenance record beastmode
+already requires becomes the trace.
+
+**3. The trap: LangSmith must never become the source of truth for the gate.**
+LangSmith records what the SDK reports, which is exactly the `response_metadata`
+P0.1 is investigating. It is therefore tempting to read drift out of the trace.
+Don't. The gate stays `scripts/lib/acn_meta.py` reading `meta.json` off disk.
+Tracing being off, unreachable, rate-limited, or sampled must have **zero**
+effect on whether a run is `validated`. An observability outage that turns a
+safety gate green is the same fail-open class the v2.3 review closed twice.
+
+Traces may *display* drift; they may never *decide* it.
+
+**4. What to attach so the trace is useful to beastmode specifically.** Default
+LangGraph traces show node names and tokens. Beastmode needs its own vocabulary
+on them:
+
+- `metadata`: `goal_id`, `thread_id`, `phase`, `seat` (director/watcher/executor),
+  `autonomy`, `harness`, `requested_model`, `actual_model`, `beastmode_version`
+- `tags`: `beastmode`, `phase:design`, `seat:executor`, and — the valuable one —
+  `drift` / `unverifiable` stamped on any run whose gate verdict wasn't `ok`
+
+That last tag is the whole payoff: "show me every run in the last month where a
+child drifted off its pinned model" becomes a filter instead of a grep across
+run directories.
+
+**5. Privacy is the real blocker, not cost.** Beastmode prompts contain the
+codebase — diffs, file contents, repo paths, design packages. The worker
+contract keeps secrets out of *prompts*, but source code is not nothing. Three
+postures, in order of preference:
+- **self-hosted LangSmith** via `LANGSMITH_ENDPOINT` — traces never leave your
+  network
+- **input/output masking** — LangSmith supports hiding inputs/outputs; confirm
+  the exact env-var / anonymizer surface at implementation time rather than
+  trusting this doc
+- **off** — the default
+
+**6. Cost, for the evolver.** LangSmith bills on ingested traces. A `forever`
+graph at high fan-out running for days generates enormous span volume. Sampling
+policy is a prerequisite for that phase, not a tuning step after it.
+
+**7. OpenTelemetry is the escape hatch.** LangSmith has native OTel support in
+both directions — the SDK exports OTLP, and `OTEL_EXPORTER_OTLP_ENDPOINT` /
+`OTEL_EXPORTER_OTLP_HEADERS` redirect it anywhere. So the instrumentation
+decision and the vendor decision are separable: instrument once, and let the
+operator point it at LangSmith, Langfuse, or their own collector. **Design the
+metadata and span shape as OTel-compatible from the start**, so choosing a
+backend never means re-instrumenting.
+
 ---
 
 ## Q9 — What's the budget ceiling for a `forever` run?

--- a/.planning/langgraph/OPEN-QUESTIONS.md
+++ b/.planning/langgraph/OPEN-QUESTIONS.md
@@ -99,7 +99,8 @@ rather than "beastmode is another coding agent".
 
 > ### ✅ DECIDED — A: pipeline first, evolver as P7.
 >
-> Phase order in `ROADMAP.md` stands as written. P7 stays gated on P1–P6.
+> Phase order in `ROADMAP.md` stands as written. The evolver stays gated on
+> every phase before it (now P8 — a composability phase was later inserted at P6).
 
 Your two messages describe different graphs:
 

--- a/.planning/langgraph/OPEN-QUESTIONS.md
+++ b/.planning/langgraph/OPEN-QUESTIONS.md
@@ -4,9 +4,35 @@ Q1–Q3 change the phase order in `ROADMAP.md` and should be answered before P1
 starts. Q4–Q10 can be answered during P0/P1. Each has a recommendation, so
 silence is not a blocker — but a different answer means different phases.
 
+**Q1, Q2, Q3, Q5 are now DECIDED** (2026-08-03) — see the ✅ blocks. Q4, Q6–Q10
+remain open.
+
 ---
 
 ## Q1 — What is the deliverable, exactly? (**blocks P1**)
+
+> ### ✅ DECIDED — "Beastmode must still work without LangGraph. It's an upgrade for beastmode users."
+>
+> This is neither A nor B nor C as posed — it's a **constraint that outranks the
+> question**, plus a priority. Recorded as:
+>
+> **C1 (hard constraint, non-negotiable): LangGraph is strictly additive.**
+> Beastmode without LangGraph works exactly as it does today. No bash script,
+> no test, no schema, no doc, and no adapter acquires a hard Python dependency.
+> A user who never installs the package sees zero behavior change. This is
+> promoted out of the risk register (§5.4) into `REQUIREMENTS.md` §2 as
+> **invariant 0**, and it is a merge-blocking exit on every phase — not a
+> footnote.
+>
+> **C2 (priority): existing beastmode users are the primary audience.**
+> `bm --harness langgraph` is therefore a first-class deliverable, not a P5
+> afterthought. The package still ships (it's the implementation, and it's the
+> adoption channel for LangGraph users), but "beastmode users get an upgrade
+> and lose nothing" is the success criterion that decides ties.
+>
+> *Assumption flagged for correction:* read as "must still work **without
+> LangGraph**". If "Langston" meant something else, say so — C1 is doing a lot
+> of load-bearing work.
 
 Three different products hide behind "enable LangGraph":
 
@@ -27,6 +53,23 @@ package in P1–P4, `bm` flag in P5.
 ---
 
 ## Q2 — Do LangGraph nodes call models, or drive subprocesses? (**blocks P3/P4**)
+
+> ### ✅ DECIDED — C: split by seat.
+>
+> Judgment seats (director, watcher, validator) call chat models directly —
+> they read and decide, they don't write files. Executor seats spawn the
+> existing coding agents (`pi`, `claude -p`, `codex exec`, `delegate_task`) as
+> subprocesses in `git worktree`s.
+>
+> Consequences now locked into the roadmap:
+> - Hard rule 1 survives untouched, because the only nodes that write files are
+>   still separate processes with their own permission config.
+> - Direct-call judgment nodes depend on provider response metadata for
+>   `actual_model`. **P0.1 is now gating**: if a frontier provider we intend to
+>   use can't prove the serving model, its judgment nodes are `unverifiable` and
+>   must fall back to subprocess. P0.1's exit adds a per-provider
+>   direct-call-viable column.
+> - Fallback if P0.1 goes badly: option B (all seats subprocess).
 
 This is the single biggest architectural call, and it decides whether hard
 rule 1 survives.
@@ -53,6 +96,10 @@ rather than "beastmode is another coding agent".
 ---
 
 ## Q3 — Which graph ships first? (**blocks P3 vs P7 ordering**)
+
+> ### ✅ DECIDED — A: pipeline first, evolver as P7.
+>
+> Phase order in `ROADMAP.md` stands as written. P7 stays gated on P1–P6.
 
 Your two messages describe different graphs:
 
@@ -87,6 +134,35 @@ the packaging split.
 ---
 
 ## Q5 — May the graph rewrite itself?
+
+> ### ✅ DECIDED — B: topology mutation permitted at `--autonomy high` only.
+>
+> This **loosens a rule the repo earned**, so it ships with guardrails rather
+> than as a bare permission. Below `high`, the notes-only rule is unchanged: the
+> graph proposes a topology diff, a human approves it.
+>
+> Guardrails (proposed — these are my constraints, not your instruction; push
+> back on any of them):
+>
+> 1. **A mutation may not remove or weaken a gate.** Not `gate_provenance`, not
+>    `gate_merge`, not the budget ceiling. A graph that can delete its own drift
+>    gate at `high` autonomy is a graph with no drift gate — `high` is exactly
+>    the mode where nobody is watching. Enforced by validating the post-mutation
+>    graph against a required-node/required-edge set before it is compiled.
+> 2. **Mutations are checkpointed and diffable.** The pre-mutation topology is
+>    persisted, the diff is rendered as mermaid, and both land in the phase
+>    report. A self-edit nobody can read is not auditable.
+> 3. **Mutation is a surfacing event.** `schema/autonomy-levels.json` gets
+>    `topology_mutation` added to `high.always_surfaces`, alongside
+>    `budget_limited` and the watcher-unavailable case. `high` never means
+>    silent.
+> 4. **Bounded per run.** A mutation counter with a ceiling, so a graph cannot
+>    churn its own shape indefinitely.
+>
+> This makes `schema/autonomy-levels.json` and `SKILL.md`'s self-improvement
+> section part of the P7 diff, and it is the first time an autonomy level grants
+> a *capability* rather than just suppressing a prompt. Worth a second look
+> before P7 starts.
 
 Your framing includes "self-improvement loop that rewrites the orchestration
 itself" and "a graph agents can walk, branch, or rewrite". Today that is

--- a/.planning/langgraph/REQUIREMENTS.md
+++ b/.planning/langgraph/REQUIREMENTS.md
@@ -1,0 +1,312 @@
+# Requirements — Beastmode as a first-class LangGraph layer
+
+Status: **draft for review**. Nothing here is committed to implementation until
+the open questions in `OPEN-QUESTIONS.md` are answered — three of them change
+the phase order in `ROADMAP.md`.
+
+Target: beastmode **v2.4.0**, shipping a Python distribution alongside the
+existing skill. LangGraph pinned at **1.2.x** (latest 1.2.10, 2026-07-28).
+
+---
+
+## 1. Why this is not a small change
+
+Beastmode today has **no runtime**. It is:
+
+| Layer | What it actually is |
+|---|---|
+| The framework | `SKILL.md` (36 KB of prose an LLM harness reads) |
+| The vocabulary | `schema/*.json` — 5 files, machine-readable, load-bearing since v2.3 |
+| The control flow | `scripts/bm` — 260 lines of bash that resolves seats, preflights, then `exec`s a harness |
+| The enforcement | `scripts/enforce-models` + `scripts/acn-report`, both calling `scripts/lib/acn_meta.py` (348 lines, the only Python in the repo) |
+| The execution | somebody else's agent: `pi`, `delegate_task`, `claude -p`, `codex exec` |
+
+The orchestration is *prose executed by a model*, and the gates are *postflight
+filesystem checks* over `meta.json` files the workers dropped. There is no
+`pyproject.toml`, no `package.json`, no dependency file of any kind.
+
+LangGraph is a Python library with typed state, a checkpointer, and an
+in-process scheduler. Adopting it means the repo grows a **first-class runtime
+and its first dependency tree**. That is the real cost of this effort — bigger
+than any single graph we draw.
+
+The upside is equally concrete: the beastmode loop stops being a set of
+instructions a model may or may not follow, and becomes a graph that *cannot*
+skip a gate, because the gate is an edge.
+
+---
+
+## 2. What must survive the port
+
+These are the invariants the last two releases were spent earning. A LangGraph
+port that loses any of them is a regression, not a feature.
+
+1. **One vocabulary.** `schema/*.json` stays the source of truth. Python types
+   are *derived from or validated against* the JSON — never hand-copied.
+   `.learnings/BEASTMODE.md` already records what happens when `schema/` becomes
+   decorative: four documents called it the source of truth while no code read
+   it, and the gate silently hard-coded its own field list.
+2. **One gate implementation.** `scripts/lib/acn_meta.py` remains the only
+   thing that decides `ok` / `drift` / `unverifiable`. The graph *calls* it. It
+   does not get a Python twin — that is the exact "one contract, two
+   implementations" failure the v2.3 review found between `enforce-models` and
+   `acn-report`.
+3. **Three verdicts, two of them failures.** A gate must have a verdict for
+   "cannot determine", and that verdict must fail. LangGraph's retry and error
+   handling must not be able to convert `unverifiable` into a pass or a silent
+   skip.
+4. **A gate over a set fails if any member fails.** `Send` fan-out aggregation
+   must not let a passing sibling carry a batch. Recognition of a child record
+   stays separate from judgment of it (`is_child_record` vs `Row._classify`).
+5. **Main tree stays clean.** Executors work in isolated worktrees and never
+   commit, push, or touch secrets. See §5 — this is the constraint LangGraph
+   fits *worst*, and it drives the biggest design decision in the effort.
+6. **Gates are blocking below `high`.** Default autonomy is `medium`.
+7. **Model drift always surfaces**, at every autonomy level, and blocks
+   `validated`.
+8. **Self-improvement writes notes only.** No lasting behavior change inside a
+   run. A graph that rewrites its own topology mid-run violates this and needs
+   an explicit, separately-approved decision (see `OPEN-QUESTIONS.md` Q5).
+
+---
+
+## 3. Concept mapping — beastmode → LangGraph
+
+| Beastmode concept | LangGraph primitive | Confidence | Notes |
+|---|---|---|---|
+| The loop (Preflight → Contract → Design → Delegate → Validate → Review → Merge → Self-Improve) | `StateGraph` nodes + `add_edge` | **High** | Faithful port; a mostly-linear DAG with conditional edges at gates |
+| Acceptance contract | typed `AcceptanceContract` in graph state, written by the contract node | **High** | Field names come from `.planning/ACCEPTANCE.md` template in `SKILL.md` §Step 1 |
+| Autonomy level (`low`/`medium`/`high`) | `context_schema` → read via `Runtime[BeastmodeContext]` | **High** | Config, not state — it does not change during a run |
+| "Gates are blocking below high" | `interrupt()` inside the gate node when `autonomy != "high"` | **High** | See §4 — has a sharp edge |
+| ACN batch fan-out | `Send(node, payload)` from a dispatch node | **High** | `concurrency_default: 3` → `config={"max_concurrency": 3}` |
+| Lane grouping for prompt-cache warmth | **no native primitive** | **Low** | See §5.3 — a real, costed degradation |
+| Per-child `meta.json` | `ChildMeta` appended to state via reducer **and** written to the run dir | **High** | Keep the filesystem write so `acn-report` / `enforce-models --check-meta` keep working unchanged |
+| Drift / provenance gate | a `gate_provenance` node that shells to `acn_meta.check()` | **High** | Import the module, call `check()`; do not reimplement |
+| Model preflight (`enforce-models`, exit 2) | build-time validation before `.compile()`, raising `SeatUnavailable` | **High** | Fail before the graph exists, matching today's "never start against an unresolvable model" |
+| requested vs actual model | `SeatModel` wrapper recording `response_metadata` | **Low** | ⚠️ **Spike required** — see §5.1 |
+| Worktree isolation | executor node spawns a subprocess inside `git worktree add` | **Medium** | See §5.2 |
+| MemroOS-style durable handoff | checkpointer (`SqliteSaver` local, `PostgresSaver` prod); `thread_id` = goal id | **High** | This is the single best fit in the whole mapping |
+| Cross-session project memory (PRD, priority list) | LangGraph `Store` (cross-thread), not the checkpointer | **Medium** | Only needed for the "forever" graph (P7) |
+| Session restart / context re-pack | a re-pack node + `Command(goto=...)` | **Medium** | Replaces "restart the session and recompact" |
+| Phase usage report | `usage_metadata` accumulated by a reducer, rendered by `acn-report` | **High** | |
+| Self-improvement entry | node appends to `.learnings/BEASTMODE.md` | **High** | Notes only |
+| Living flowchart | `graph.get_graph().draw_mermaid()` | **High** | Free. Also the answer to "prompt a graph and drop it in" — the graph becomes an inspectable artifact |
+| Multi-day unattended evolution | checkpointer + **external supervisor** | **Medium** | See §5.5 — checkpoints are not durable execution |
+
+---
+
+## 4. LangGraph API facts this design depends on
+
+Verified against LangGraph 1.2.x docs, August 2026. If any of these change,
+the phase that depends on it is invalidated.
+
+- **`interrupt()` requires a checkpointer.** No checkpointer, no gates. This
+  makes persistence a P3 dependency, not a P5 nice-to-have.
+- **`interrupt()` replays its node from the top on resume.** Everything in a
+  gate node before the `interrupt()` call runs *twice*. Gate nodes must
+  therefore be side-effect-free, and `interrupt()` should be the first
+  statement. A gate node that writes the phase report before interrupting will
+  write it twice.
+- **Resume is `Command(resume=<value>)`** on the same `thread_id`.
+- **`durability`** has three modes: `"exit"` (checkpoint only at the end,
+  fastest), `"async"` (persist while the next step runs), `"sync"` (persist
+  before the next step starts). Any run that can hit a gate needs at least
+  `"async"`; `"sync"` for anything gate-bearing that we care about resuming
+  exactly. `"exit"` is only acceptable for `--autonomy high` fire-and-forget.
+- **`Send` is the map-reduce primitive** — dynamic fan-out from runtime data,
+  which is exactly the ACN batch shape.
+- **Deferred nodes** delay a node until all pending branches finish — the
+  correct primitive for the consolidation step after a ragged fan-out, where
+  children finish at different times.
+- **`set_node_defaults`** sets `retry_policy` / `timeout` / `cache_policy` /
+  `error_handler` once per graph instead of per `add_node`.
+- **Subgraphs: only the parent should carry a checkpointer.** Relevant because
+  a phase-as-subgraph layout is otherwise attractive.
+- **`max_concurrency`** in the run config caps concurrent node execution.
+
+Sources are listed at the bottom of this document.
+
+---
+
+## 5. Risks, ranked
+
+### 5.1 — `actual_model` may not be knowable (**HIGH — blocks the drift gate**)
+
+Beastmode's headline guarantee is that drift always surfaces. Today that works
+because the *worker harness* writes `actual_model` into `meta.json` from its own
+journal. Move orchestration into LangGraph and, for any node that calls a chat
+model directly, the only source of truth is the provider's response metadata —
+typically `response_metadata["model_name"]` or `usage_metadata`.
+
+**Some providers echo the resolved model. Some echo the alias you sent. Some
+echo nothing.** Where a provider does not report it, `actual_model` is
+unknowable and every child through that lane is `unverifiable` — which
+fail-closed correctly turns into a red gate, i.e. the feature is unusable on
+that provider rather than silently wrong. That is the right failure mode and
+also a potentially fatal one for adoption.
+
+**Mitigation:** P0 spike measures this per provider before anything is built,
+and produces a support matrix. Providers that cannot prove the serving model
+are documented as unsupported for direct-call nodes (they remain fine behind a
+subprocess executor that writes its own meta).
+
+### 5.2 — In-process nodes cannot be constrained (**HIGH — hard rule 1**)
+
+"Workers never commit/push", "workers never access secrets", and "stay inside
+`allowed_paths`" are enforced today by the worker being a *separate process*
+with its own permission config (`pi-permission-system`) and its own worktree.
+A LangGraph node is a Python function in the orchestrator's own process with
+the orchestrator's own environment and credentials. Prose cannot constrain it.
+
+**Mitigation and the biggest design call in this effort:** LangGraph replaces
+`scripts/bm`'s *control flow*, not the executor. Executor nodes spawn the
+existing coding agents (`pi`, `claude -p`, `codex exec`, `delegate_task`) as
+subprocesses inside `git worktree`s, exactly as today. Beastmode-on-LangGraph
+then becomes a **harness-of-harnesses** — which is a stronger product position
+than a fifth harness, because it orchestrates any coding agent rather than
+competing with them.
+
+This is Q2 in `OPEN-QUESTIONS.md`. If the answer is instead "nodes call chat
+models directly", hard rule 1 needs to be rewritten and sandboxing becomes a
+phase of its own.
+
+### 5.3 — Lane grouping has no LangGraph expression (**MEDIUM — cost**)
+
+`SKILL.md` §Step 3 is explicit: batch same-lane workers consecutively so the
+shared prefix stays cache-warm (0.10x reads vs a 1.25x write on every lane
+switch). `Send` hands the runtime a set of tasks and lets it schedule them.
+Ten workers across three lanes, interleaved, pay a cache write on every switch.
+
+**Mitigation options:** (a) group by lane into sequential `Send` super-steps —
+loses some parallelism, keeps the discount; (b) accept the degradation and
+measure it; (c) custom scheduling in the dispatch node. Decide with numbers
+from the P0 spike, not in advance.
+
+### 5.4 — The repo becomes polyglot (**MEDIUM**)
+
+First `pyproject.toml`, first dependency tree, first release process, first
+version-sync problem (`SKILL.md` frontmatter `version:` vs package version).
+CI currently runs `./tests/run-all.sh` on Python 3.11 with **zero installs**
+and asserts the working tree is unchanged afterward. A Python package adds an
+install step, a lockfile, and a lane that can break for reasons unrelated to
+beastmode. `langgraph` also pulls `langchain-core` and friends — the transitive
+tree is not small.
+
+**Mitigation:** the LangGraph lane is *additive and optional*. `tests/run-all.sh`
+keeps passing with no Python deps installed; graph tests live behind a separate
+CI job that installs the package. A user who never touches LangGraph sees no
+change.
+
+### 5.5 — Checkpoints are not durable execution (**MEDIUM — only for P7**)
+
+The checkpointer saves state, but nothing detects failure. If the process
+crashes, no one knows and nothing resumes. The "runs for days while you ignore
+it" story therefore needs a supervisor *outside* LangGraph: a cron/systemd loop
+that re-invokes the thread, or LangGraph Platform, or Temporal/Inngest.
+Promising multi-day autonomy on a bare checkpointer would be a false claim.
+
+### 5.6 — CrewAI later means a rewrite unless the core is split now (**HIGH, cheap to prevent**)
+
+CrewAI Flows (`@start` / `@listen` / `@router`) is an event-driven decorator
+model, not a graph-construction API. Nothing about a `StateGraph`-shaped
+codebase transfers. But almost everything valuable in beastmode is
+*framework-neutral*: seat resolution, tier routing, the acceptance contract,
+the provenance gate, the usage report, worker-contract prompts.
+
+**Mitigation — and this is why the CrewAI ask matters in phase 1 even though
+CrewAI is out of scope:** ship `beastmode-core` (zero framework imports) plus a
+thin `beastmode-langgraph` binding. A CrewAI binding later is then a small
+adapter over the same core instead of a second implementation. If phase 1 ships
+LangGraph-native, "one at a time" turns into "twice".
+
+### 5.7 — Schema fork (**HIGH, mitigated by construction**)
+
+The moment a Python `TypedDict` restates `meta_json_required_fields`, the JSON
+and the code can disagree. `tests/test-acn-parity.sh` already asserts the prose
+in `references/acn-contract.md` matches the schema; it must be extended to
+assert the Python state shape matches too.
+
+---
+
+## 6. Package layout (proposed)
+
+Framework-neutral core, thin bindings. Reserves the CrewAI slot without
+building it.
+
+```
+python/
+  pyproject.toml                     # workspace / single dist, TBD by Q4
+  src/beastmode/
+    core/                            # ZERO framework imports. Enforced by a test.
+      __init__.py
+      schema.py                      #   loads schema/*.json — never restates it
+      seats.py                       #   alias -> provider/model, tier, family
+      contract.py                    #   AcceptanceContract type + template
+      provenance.py                  #   thin wrapper over scripts/lib/acn_meta.py
+      routing.py                     #   verification-cost routing rule
+      prompts.py                     #   worker contract, phase, gate, drift prompts
+      report.py                      #   phase usage report
+      worktree.py                    #   git worktree lifecycle
+      executors/                     #   subprocess drivers: pi, claude, codex, hermes
+    langgraph/                       # the binding
+      __init__.py
+      state.py                       #   BeastmodeState + reducers
+      context.py                     #   BeastmodeContext (autonomy, seats, budget)
+      nodes/                         #   one module per node
+      graphs/
+        pipeline.py                  #   P3: the beastmode loop as a DAG
+        forever.py                   #   P7: the continuous evolver
+      gates.py                       #   interrupt() wrappers
+      dispatch.py                    #   Send fan-out, lane grouping
+    crewai/                          # P8 — reserved, empty, not shipped
+  tests/
+```
+
+`scripts/lib/acn_meta.py` is **imported**, not vendored. If the distribution
+must be installable standalone, it moves into `beastmode/core/` and the bash
+scripts import it from there — one file, one location, either way.
+
+---
+
+## 7. Platform and dependency requirements
+
+| Requirement | Minimum | Why |
+|---|---|---|
+| `python` | **3.11** | Matches `.github/workflows/tests.yml` and `acn_meta.py`'s `Path \| None` syntax |
+| `langgraph` | **1.2.x** | `durability` modes, deferred nodes, `set_node_defaults`, `Runtime[ContextT]` |
+| `langgraph-checkpoint-sqlite` | latest | Local default checkpointer |
+| `langgraph-checkpoint-postgres` | latest | Production / long-running. Call `.setup()` on first use; manual connections need `autocommit=True` + `row_factory=dict_row` |
+| `langchain-core` | transitive | Chat model interface, `usage_metadata` |
+| provider packages | optional extras | `[anthropic]`, `[openai]`, `[minimax]`, … — never a hard dep |
+| `git` | 2.5+ | `git worktree` |
+| LangSmith | **optional** | Tracing. Hosted; must not be required. `acn-report` stays the offline path |
+
+Nothing above may become a requirement of the existing skill. A beastmode user
+on bash-only must see zero change.
+
+---
+
+## 8. Out of scope for this effort
+
+- CrewAI binding (layout reserved; implementation is P8, a separate effort)
+- LangGraph Platform / hosted deployment
+- Replacing any existing harness — hermes / pi / claude / codex adapters are untouched
+- Rewriting `scripts/bm` in Python
+- Anything that changes the meaning of `schema/*.json`
+- Self-modifying graph topology (needs its own approval — Q5)
+
+---
+
+## Sources
+
+- [langgraph · PyPI](https://pypi.org/project/langgraph/) — version 1.2.10, 2026-07-28
+- [Interrupts — Docs by LangChain](https://docs.langchain.com/oss/python/langgraph/interrupts)
+- [Durable execution — Docs by LangChain](https://docs.langchain.com/oss/python/langgraph/durable-execution)
+- [Durability | langgraph | LangChain Reference](https://reference.langchain.com/python/langgraph/types/Durability)
+- [Use the graph API — Docs by LangChain](https://docs.langchain.com/oss/python/langgraph/use-graph-api)
+- [Deferred nodes in LangGraph — LangChain Changelog](https://changelog.langchain.com/announcements/deferred-nodes-in-langgraph)
+- [Memory — Docs by LangChain](https://docs.langchain.com/oss/python/langgraph/add-memory)
+- [langgraph-checkpoint-postgres · PyPI](https://pypi.org/project/langgraph-checkpoint-postgres)
+- [Why Checkpoints Aren't Durable Execution — Diagrid](https://www.diagrid.io/blog/checkpoints-are-not-durable-execution-why-langgraph-crewai-google-adk-and-others-fall-short-for-production-agent-workflows)
+- [CrewAI Flows: Production Multi-Agent Guide 2026](https://www.jahanzaib.ai/blog/crewai-flows-production-multi-agent-guide)
+- [LangGraph vs CrewAI: Honest Comparison for 2026](https://fast.io/resources/langgraph-vs-crewai/)

--- a/.planning/langgraph/REQUIREMENTS.md
+++ b/.planning/langgraph/REQUIREMENTS.md
@@ -41,6 +41,22 @@ skip a gate, because the gate is an edge.
 These are the invariants the last two releases were spent earning. A LangGraph
 port that loses any of them is a regression, not a feature.
 
+0. **LangGraph is strictly additive. Beastmode works without it.** *(Decided
+   2026-08-03 — Q1.)* No bash script, test, schema, doc, or adapter acquires a
+   hard Python dependency. `./tests/run-all.sh` passes on a machine with zero
+   Python packages installed. A user who never installs the package sees no
+   behavior change, and no existing `bm` invocation changes meaning. This
+   outranks every other consideration in this document: where LangGraph
+   idiom and this invariant conflict, this invariant wins. It is a
+   merge-blocking exit on **every** phase, not a §5 risk to manage.
+
+   The corollary is a priority: **existing beastmode users are the primary
+   audience.** `bm --harness langgraph` is a first-class deliverable, not a
+   late add-on. The package still ships — it is the implementation, and it is
+   the adoption channel for LangGraph users who arrive from the other
+   direction — but "beastmode users get an upgrade and lose nothing" is what
+   decides ties.
+
 1. **One vocabulary.** `schema/*.json` stays the source of truth. Python types
    are *derived from or validated against* the JSON — never hand-copied.
    `.learnings/BEASTMODE.md` already records what happens when `schema/` becomes
@@ -64,9 +80,14 @@ port that loses any of them is a regression, not a feature.
 6. **Gates are blocking below `high`.** Default autonomy is `medium`.
 7. **Model drift always surfaces**, at every autonomy level, and blocks
    `validated`.
-8. **Self-improvement writes notes only.** No lasting behavior change inside a
-   run. A graph that rewrites its own topology mid-run violates this and needs
-   an explicit, separately-approved decision (see `OPEN-QUESTIONS.md` Q5).
+8. **Self-improvement writes notes only — below `high`.** *(Amended 2026-08-03
+   — Q5.)* At `low` and `medium` autonomy the rule is unchanged: a run records
+   lessons, and any lasting behavior change is a separate user-approved task.
+   At `--autonomy high`, the graph **may** mutate its own topology, subject to
+   four guardrails: a mutation may not remove or weaken a gate; the pre-mutation
+   topology is checkpointed and the diff rendered; mutation is added to
+   `high.always_surfaces` in `schema/autonomy-levels.json`; and mutations are
+   bounded per run. Scope: P7 only — nothing in P1–P6 mutates anything.
 
 ---
 
@@ -150,7 +171,7 @@ and produces a support matrix. Providers that cannot prove the serving model
 are documented as unsupported for direct-call nodes (they remain fine behind a
 subprocess executor that writes its own meta).
 
-### 5.2 — In-process nodes cannot be constrained (**HIGH — hard rule 1**)
+### 5.2 — In-process nodes cannot be constrained (**HIGH — hard rule 1**) — *resolved by Q2*
 
 "Workers never commit/push", "workers never access secrets", and "stay inside
 `allowed_paths`" are enforced today by the worker being a *separate process*
@@ -166,9 +187,17 @@ then becomes a **harness-of-harnesses** — which is a stronger product position
 than a fifth harness, because it orchestrates any coding agent rather than
 competing with them.
 
-This is Q2 in `OPEN-QUESTIONS.md`. If the answer is instead "nodes call chat
-models directly", hard rule 1 needs to be rewritten and sandboxing becomes a
-phase of its own.
+**Decided (Q2): split by seat.** Judgment seats — director, watcher, validator —
+call chat models directly, because they read and decide and never write files.
+Executor seats are subprocesses in worktrees. Hard rule 1 survives untouched,
+since the only nodes that touch the filesystem are still separate processes with
+their own permission config.
+
+The residual exposure is narrow but real: direct-call judgment nodes get their
+`actual_model` only from provider response metadata, so risk 5.1 now **gates**
+this decision rather than sitting beside it. P0.1's matrix gains a
+`direct-call viable` column, and any frontier provider that cannot prove its
+serving model falls back to a subprocess seat rather than being trusted.
 
 ### 5.3 — Lane grouping has no LangGraph expression (**MEDIUM — cost**)
 
@@ -182,7 +211,7 @@ loses some parallelism, keeps the discount; (b) accept the degradation and
 measure it; (c) custom scheduling in the dispatch node. Decide with numbers
 from the P0 spike, not in advance.
 
-### 5.4 — The repo becomes polyglot (**MEDIUM**)
+### 5.4 — The repo becomes polyglot (**HIGH — this is now invariant 0, not a risk**)
 
 First `pyproject.toml`, first dependency tree, first release process, first
 version-sync problem (`SKILL.md` frontmatter `version:` vs package version).
@@ -192,10 +221,11 @@ install step, a lockfile, and a lane that can break for reasons unrelated to
 beastmode. `langgraph` also pulls `langchain-core` and friends — the transitive
 tree is not small.
 
-**Mitigation:** the LangGraph lane is *additive and optional*. `tests/run-all.sh`
-keeps passing with no Python deps installed; graph tests live behind a separate
-CI job that installs the package. A user who never touches LangGraph sees no
-change.
+**Mitigation — now mandatory, not a mitigation:** per Q1 this is invariant 0.
+`tests/run-all.sh` keeps passing with no Python deps installed; graph tests live
+behind a separate CI job that installs the package. Every phase carries the
+install-free bash-lane assertion as an exit, so the dependency cannot leak in
+gradually. A user who never touches LangGraph sees no change.
 
 ### 5.5 — Checkpoints are not durable execution (**MEDIUM — only for P7**)
 

--- a/.planning/langgraph/REQUIREMENTS.md
+++ b/.planning/langgraph/REQUIREMENTS.md
@@ -87,7 +87,8 @@ port that loses any of them is a regression, not a feature.
    four guardrails: a mutation may not remove or weaken a gate; the pre-mutation
    topology is checkpointed and the diff rendered; mutation is added to
    `high.always_surfaces` in `schema/autonomy-levels.json`; and mutations are
-   bounded per run. Scope: P7 only — nothing in P1–P6 mutates anything.
+   bounded per run. Scope: the evolver phase only — nothing before it mutates
+   anything.
 
 ---
 

--- a/.planning/langgraph/ROADMAP.md
+++ b/.planning/langgraph/ROADMAP.md
@@ -107,6 +107,15 @@ Retrofitting any of them is a rewrite of every node.
   and a written statement of which nodes are safe to re-run. Gate nodes replay
   on resume (P0.2); executor nodes must be idempotent against a half-finished
   worktree.
+- **Traceable, vendor-neutral, and never load-bearing.** Nodes carry beastmode
+  metadata and tags (`goal_id`, `phase`, `seat`, `autonomy`, `requested_model`,
+  `actual_model`; tags `drift` / `unverifiable` on a non-`ok` verdict) shaped to
+  be OTel-compatible, so the backend is an operator choice rather than a
+  rewrite. Two hard constraints: **(a)** each subprocess executor synthesizes a
+  child span from the `meta.json` it already writes, or the majority of every
+  run's tokens and wall-clock is invisible; **(b)** tracing being off,
+  unreachable, or sampled has **zero** effect on any gate verdict — traces may
+  display drift, never decide it. See `OPEN-QUESTIONS.md` Q8.
 
 ---
 
@@ -406,6 +415,11 @@ strategically pointless.
   the PRD + priority list surviving a restart
 - `python/README.md` for the PyPI page — leads with the P6 drop-in primitives,
   not with `build_pipeline()`; the smallest on-ramp goes first
+- `references/observability.md` — the LangSmith / OTel onboarding page: the
+  three env vars, self-hosted `LANGSMITH_ENDPOINT`, what the trace tree looks
+  like, how subprocess child spans are reconstructed from `meta.json`, the
+  metadata/tag vocabulary, masking options, sampling guidance, and the standing
+  rule that tracing is never load-bearing for a gate
 
 **Exit (deterministic)**
 - `test-acn-parity.sh` gains: Python `ChildMeta` fields == schema
@@ -417,6 +431,12 @@ strategically pointless.
   the repo — the v2.3 fixture-rewriting bug)
 - `python -m build` produces a wheel; the wheel imports with no provider SDKs
   present
+- With `LANGSMITH_TRACING=true`, one run produces a trace whose executor nodes
+  each carry a child span reconstructed from the child's `meta.json` — token
+  counts in the trace reconcile against `acn-report`'s phase report
+- With tracing off, unreachable, and pointed at a dead endpoint, all three
+  produce byte-identical gate verdicts (negative-tested — this is the fail-open
+  the rule exists to prevent)
 
 ---
 

--- a/.planning/langgraph/ROADMAP.md
+++ b/.planning/langgraph/ROADMAP.md
@@ -1,0 +1,343 @@
+# ROADMAP — Beastmode on LangGraph (v2.4.0)
+
+Branch: `claude/beastmode-langgraph-planning-1w3bl8` (planning only — no
+implementation on this branch). Implementation branches per phase, merged to
+`main` behind the existing CI gate.
+
+Read `REQUIREMENTS.md` first — it holds the concept mapping, the LangGraph API
+facts each phase depends on, and the risk register phases P0–P2 exist to retire.
+Read `OPEN-QUESTIONS.md` before starting P1: **Q1–Q3 change this phase order**.
+
+---
+
+## Goal
+
+Make beastmode a **first-class LangGraph layer**: a `pip`-installable package
+that gives LangGraph users the beastmode loop — model-tier routing, acceptance
+contracts, provenance/drift gates, ACN parallel fan-out, autonomy gating,
+per-phase usage reporting, and the self-improvement checkpoint — as ready-to-use
+`StateGraph`s, without asking them to leave LangGraph.
+
+Secondary and equally load-bearing: keep the core framework-neutral so a CrewAI
+binding later is an adapter, not a rewrite (`REQUIREMENTS.md` §5.6).
+
+## Non-goals
+
+Replacing any existing harness. Rewriting `bm` in Python. Hosted deployment.
+CrewAI implementation. Changing the meaning of `schema/*.json`. Self-modifying
+graph topology.
+
+## Role routing for this effort
+
+Per hard rule 9, frontier lanes are explicit-only — the seats below are a
+*proposal*, not an authorization to spend. Confirm before P0 runs.
+
+- **Director / orchestrator:** frontier. This effort is architecture-heavy: a
+  new runtime, a new dependency tree, and five invariants that must survive a
+  paradigm change. This is not an economy-tier consolidation pass like v2.2.
+- **Worker (executor):** MiniMax-M3 for bounded slices — node authoring against
+  a written interface, test authoring, docs. Every P1–P6 task is specified to be
+  cheap-routable (concrete interface + verify command), per the verification-cost
+  rule.
+- **Watcher / validator:** cross-family frontier, and **mandatory on P2 and P4**.
+  `.learnings/BEASTMODE.md` records that the last fail-open in the drift gate was
+  caught by a cross-family reviewer on a diff with 19 passing checks and green
+  CI. P2 and P4 are exactly that shape again.
+
+---
+
+## Phases
+
+| Phase | Scope | Exit (deterministic) |
+|---|---|---|
+| **P0** | Spikes — retire the unknowns, throwaway code | Support matrix + 3 written verdicts (below) |
+| **P1** | `python/` skeleton, `beastmode.core`, schema loader, CI lane | `pytest` green; import-linter proves `core` has zero framework imports; `tests/run-all.sh` still passes with no Python deps installed |
+| **P2** | Seat layer + provenance: `SeatModel`, `ChildMeta`, drift gate | Every `acn_meta.py` fixture returns the identical verdict through the Python path; negative test per verdict |
+| **P3** | `graphs/pipeline.py` — the loop as a DAG, gates via `interrupt()` | A run at `--autonomy medium` stops at each gate and resumes on `Command(resume=…)`; at `high` it does not stop |
+| **P4** | ACN fan-out: `Send` dispatch, worktree subprocess executors, consolidation | 3-child batch runs concurrently; one child killed pre-meta ⇒ gate fails; main tree unmodified |
+| **P5** | Persistence, `bm --harness langgraph`, mermaid export | Kill mid-run, resume from checkpoint, run completes; `--harness langgraph` preflights and runs |
+| **P6** | Docs, adapter SKILL, parity tests, release | `test-acn-parity.sh` covers the Python state shape; `SKILL.md` v2.4.0; package builds |
+| **P7** | `graphs/forever.py` — the continuous evolver (separate effort) | Gated on P1–P6 + Q3 |
+| **P8** | CrewAI binding (separate effort) | Gated on P7 |
+
+---
+
+## P0 — Spikes
+
+Throwaway code in a scratch worktree. Nothing merges. The deliverable is three
+written verdicts and one table. **This phase exists to make P1–P6 estimable**;
+skipping it means committing to a design whose central guarantee (drift
+detection) is unverified.
+
+### P0.1 — Can we prove `actual_model`? (retires risk 5.1)
+
+For each provider in `schema/families.json` (anthropic, openai-codex, kimi,
+minimax, qwen, xai, zai): send one trivial completion via `init_chat_model`
+with a deliberately *aliased* model id, and record what comes back in
+`response_metadata` and `usage_metadata`.
+
+Classify each into:
+- **echoes resolved model** — drift gate works on direct-call nodes
+- **echoes the alias we sent** — gate is blind to router substitution; direct
+  calls to this provider are `unverifiable` by construction
+- **reports nothing** — same, `unverifiable`
+
+**Exit:** a `provider → provenance capability` matrix committed to
+`references/`, plus a one-paragraph verdict on whether direct-call nodes are
+viable at all or whether **every** executor must be a subprocess (which would
+make Q2 moot and simplify P4).
+
+### P0.2 — What does `interrupt()` replay actually cost? (retires risk 5.2)
+
+Build a two-node graph with a gate that writes a file *before* `interrupt()`.
+Confirm the file is written twice on resume. Then confirm the ordering rule
+(`interrupt()` first, side effects after resume) fixes it.
+
+**Exit:** a written node-authoring rule for gate nodes, to be enforced by
+review in P3 and asserted by a test.
+
+### P0.3 — What does losing lane grouping cost? (retires risk 5.3)
+
+Fan out 9 trivial tasks across 3 lanes, twice: once lane-grouped into sequential
+`Send` super-steps, once interleaved. Compare cache-read vs cache-write tokens
+from `usage_metadata`.
+
+**Exit:** a number. If the delta is small, accept interleaving and delete the
+complexity from P4. If large, P4 gets an explicit lane-grouped dispatcher.
+
+---
+
+## P1 — Package skeleton and framework-neutral core
+
+Nothing LangGraph-specific ships in this phase. The point is the boundary.
+
+**Scope**
+- `python/pyproject.toml`, `src/beastmode/core/`, `python/tests/`
+- `core/schema.py` — loads `schema/*.json` by path resolution (same walk-up
+  strategy as `acn_meta.contract_path`). **Never restates a field list.**
+- `core/seats.py` — alias → `{provider, model, tier, family}` resolution with
+  the same precedence `bm` uses today: project-local
+  `<repo>/.beastmode/tier-aliases.json`, then `~/.beastmode/`, then
+  `scripts/tier-aliases.json`
+- `core/contract.py` — `AcceptanceContract`, fields from `SKILL.md` §Step 1
+- `core/prompts.py` — the worker contract / phase / gate / model-failure
+  strings, sourced from `scripts/lib/prompts.sh` so wording cannot fork
+- `core/routing.py` — the verification-cost rule as a function
+- Optional-extras layout so `pip install beastmode` pulls **no provider SDKs**
+- Second CI job that installs the package and runs `pytest`
+
+**Exit (deterministic)**
+- `pytest python/tests` green
+- An import-linter (or equivalent) contract fails the build if anything under
+  `beastmode/core/` imports `langgraph`, `langchain*`, or `crewai`
+- `./tests/run-all.sh` passes on a machine with **no** Python packages
+  installed — the existing bash lane must not acquire a dependency
+- `core/prompts.py` strings are asserted identical to the `prompts.sh` bodies
+  (extend `test-acn-parity.sh`, which already does substring parity for adapters)
+- `python -c "from beastmode.core.schema import acn_contract; acn_contract()"`
+  returns the same dict `acn_meta.required_meta_fields()` reads
+
+---
+
+## P2 — Seats and provenance
+
+The highest-risk phase. **Cross-family watcher review is mandatory here** —
+this is the same gate, in a new language, and the last two times it was touched
+it failed open.
+
+**Scope**
+- `core/provenance.py` — a wrapper over `scripts/lib/acn_meta.py`. It calls
+  `check()`. It does not reimplement `is_child_record`, `Row._classify`,
+  `expected_ids`, or the verdict logic.
+- `langgraph/state.py` — `ChildMeta` TypedDict whose field list is **read from**
+  `schema/acn-contract.json` at import, not typed out
+- `SeatModel` — wraps a chat model, records `requested_model` and the observed
+  `actual_model` from response metadata per P0.1, emits a `meta.json` in the
+  run dir in the canonical shape
+- Build-time seat preflight raising `SeatUnavailable` with the available
+  alternatives, mirroring `enforce-models`' exit-2 message including the
+  `BM_SKIP_MODEL_CHECK=1` bypass hint
+
+**Exit (deterministic)**
+- For every fixture in `tests/fixtures/acn-meta/`, the Python path and
+  `enforce-models --check-meta` return the **same verdict and the same exit
+  code**. This is check (e3) from `test-acn-parity.sh`, extended to a third
+  caller.
+- Negative test per verdict, each written by breaking the invariant
+  deliberately: a drifted child fails; a child missing `requested_model` fails;
+  an unreadable meta fails; an empty run dir fails without `--allow-empty`; a
+  child in `--expect` that wrote nothing fails.
+- A passing sibling does not rescue a failing one — asserted directly.
+- `SeatModel` writes a meta that `acn_meta.is_child_record()` recognises.
+- A provider from P0.1's "reports nothing" column produces `unverifiable`, not
+  a pass.
+
+---
+
+## P3 — `graphs/pipeline.py`: the loop as a DAG
+
+The faithful port. Same eight steps, same gates, same reports — as a graph.
+
+**Nodes**
+
+| Node | Tier | Does |
+|---|---|---|
+| `preflight` | — | `git status`, seat resolution, model preflight |
+| `contract` | frontier | Writes the acceptance contract into state |
+| `design` | frontier | Design package: file plan, interfaces, verify commands |
+| `challenge` | frontier (cross-family) | Adversarial pass over the design; optional at `high` |
+| `dispatch` | — | Splits the design package into ACN tasks (`Send` in P4) |
+| `execute` | economy | One per task (P4) |
+| `validate_mechanical` | economy | Runs `verify_cmds`, emits the structured report |
+| `gate_provenance` | — | `acn_meta.check()` — `ok` / `drift` / `unverifiable` |
+| `review` | frontier | Reads **report + diff**, never raw logs |
+| `gate_merge` | — | `interrupt()` below `high` |
+| `merge` | — | |
+| `self_improve` | economy | Appends to `.learnings/BEASTMODE.md`. **Notes only.** |
+
+**Edges**
+- `gate_provenance`: `ok` → `review`; `drift` | `unverifiable` → `dispatch`
+  (re-run under the pinned model), with a bounded retry count that routes to
+  `blocked` rather than looping
+- `gate_merge`: approved → `merge`; rejected → `design`
+- Every gate: `interrupt()` when `runtime.context.autonomy != "high"`, and
+  `interrupt()` is the **first statement** in the node (P0.2)
+
+**Exit (deterministic)**
+- `--autonomy medium` on a toy goal stops at each gate; `Command(resume=…)`
+  continues; `--autonomy high` runs through without stopping
+- `--autonomy low` stops at every phase transition, not only merge gates
+- A gate node re-entered after resume does not duplicate its side effects
+  (asserted by a file-write counter, per P0.2)
+- `graph.get_graph().draw_mermaid()` renders and is committed to
+  `references/langgraph-pipeline.md` — the living flowchart, free
+- `MODEL DRIFT` surfaces at `high` autonomy too, and blocks `validated`
+
+---
+
+## P4 — ACN fan-out
+
+**Scope**
+- `dispatch.py` — build `Send(...)` per task from the batch, honoring
+  `batch_required_fields` and `task_required_fields` from the schema
+- `max_concurrency` from `concurrency_default` (3)
+- Lane grouping per P0.3's number
+- `core/worktree.py` — `git worktree add` per child, torn down on completion
+- `core/executors/` — subprocess drivers for `pi`, `claude -p`, `codex exec`,
+  `delegate_task`; each writes the child `meta.json` (this is where hard rule 1
+  survives — see `REQUIREMENTS.md` §5.2)
+- Consolidation as a **deferred node** so ragged child completion doesn't run
+  the consolidator early
+
+**Exit (deterministic)**
+- A 3-task batch runs concurrently (wall clock < sum of children)
+- Each child gets its own worktree; `git status --porcelain` in the main tree
+  is empty for the whole run
+- A child killed before writing its meta ⇒ `gate_provenance` fails via
+  `--expect`, and the killed child appears in the report by id rather than
+  vanishing
+- A child that attempts `git commit` or `git push` is blocked by the executor's
+  permission config, and the attempt is recorded
+- Consolidation observes all children, including the slowest
+
+---
+
+## P5 — Persistence and the `bm` entrypoint
+
+**Scope**
+- `SqliteSaver` default, `PostgresSaver` opt-in (`.setup()` on first use;
+  `autocommit=True` + `row_factory=dict_row` on manual connections)
+- `thread_id` = beastmode goal id, so a goal is resumable by name
+- `durability` policy: `"sync"` for any gate-bearing run, `"exit"` permitted
+  only at `--autonomy high`
+- `bm --harness langgraph` in `scripts/bm`, plus the matching `enforce-models
+  --harness langgraph` preflight (package importable + checkpointer reachable)
+- `bm --graph <name>` to choose `pipeline` (later `forever`)
+
+**Exit (deterministic)**
+- Kill the process mid-phase; re-invoke with the same `thread_id`; the run
+  resumes at the last checkpoint and completes
+- `bm --harness bogus` still exits 2 (regression on `test-bm-model-check.sh`)
+- `bm --harness langgraph` with the package absent exits 2 with an install hint,
+  never a traceback
+- Time-travel: replay from an earlier checkpoint produces a divergent thread
+  without corrupting the original
+
+---
+
+## P6 — Docs, parity, release
+
+**Scope**
+- `adapters/langgraph/SKILL.md`, matching the vocabulary of the other four
+  adapters (autonomy levels, MODEL DRIFT, "no watcher no validated", gates
+  blocking below high) — `test-acn-parity.sh` check (f) already greps for this
+- `SKILL.md` → v2.4.0: harness table gains LangGraph; ACN table gains the
+  `Send` primitive
+- `README.md`, `references/acn-contract.md` harness map, `schema/` unchanged
+- `references/langgraph-pipeline.md` — the mermaid render + node/edge reference
+- A worked example: "Beastmode on LangGraph" evolving a small project, showing
+  the PRD + priority list surviving a restart
+- `python/README.md` for the PyPI page
+
+**Exit (deterministic)**
+- `test-acn-parity.sh` gains: Python `ChildMeta` fields == schema
+  `meta_json_required_fields`; adapter vocabulary check covers the new adapter;
+  the LangGraph adapter's canonical version cross-reference matches `SKILL.md`
+- `./tests/run-all.sh` green with **no** Python packages installed
+- The new CI job green with the package installed
+- CI's "working tree unchanged" assertion still passes (no test may write into
+  the repo — the v2.3 fixture-rewriting bug)
+- `python -m build` produces a wheel; the wheel imports with no provider SDKs
+  present
+
+---
+
+## P7 — `graphs/forever.py` (separate effort, gated)
+
+Not the same thing as P3, and worth stating plainly: P3 ports the *existing*
+fixed loop. P7 is the **new capability** — the continuously-cooking evolver that
+keeps a project moving for days, with a graph that cycles rather than
+terminates.
+
+Sketched nodes: `prd_maintainer`, `priority_curator`, brainstormers (fan-out by
+specialty), `implementer` (reuses P4's ACN dispatch), `reviewer`,
+`context_repacker`, `cleanup`, and a `user_redirect` priority edge that
+preempts the current cycle when the human drops in a new instruction.
+
+New concerns this raises that P3 does not:
+- Cross-thread memory — the PRD and priority list live in a `Store`, not the
+  checkpointer, because they outlive any single thread
+- Termination and budget — a graph with no exit needs a spend ceiling and an
+  anti-spin breaker (`pi-loop-police`'s role, with no LangGraph equivalent)
+- Supervision — checkpoints are not durable execution (`REQUIREMENTS.md` §5.5);
+  an external supervisor is required before any "runs for days" claim is made
+- Whether the graph may edit its own topology (Q5) — currently forbidden by
+  hard rule "self-improvement writes notes only"
+
+**Gated on:** P1–P6 shipped, and Q3 answered.
+
+---
+
+## P8 — CrewAI binding (separate effort, gated)
+
+A `beastmode.crewai` binding over the same `beastmode.core`: Flows'
+`@start` / `@listen` / `@router` wrapping the same seats, contract, provenance
+gate, and reports. Its exit criterion is that it adds **no** logic already in
+`core` — if it needs to reimplement the gate, P1's boundary failed and that is
+the finding.
+
+**Gated on:** P7, and a decision that CrewAI adoption is still worth it then.
+
+---
+
+## Success criteria for the effort
+
+- A LangGraph user runs `pip install beastmode-langgraph`, imports one builder,
+  and gets tier routing + contracts + drift gates + autonomy gating without
+  reading `SKILL.md`
+- The five invariants in `REQUIREMENTS.md` §2 hold, each asserted by a test that
+  was negative-tested by deliberately breaking it
+- `schema/*.json` is still the only source of truth; no field list exists twice
+- `scripts/lib/acn_meta.py` is still the only gate implementation
+- A bash-only beastmode user sees no change and installs nothing
+- `beastmode.core` has zero framework imports, proven by CI

--- a/.planning/langgraph/ROADMAP.md
+++ b/.planning/langgraph/ROADMAP.md
@@ -53,7 +53,7 @@ Per hard rule 9, frontier lanes are explicit-only — the seats below are a
   new runtime, a new dependency tree, and five invariants that must survive a
   paradigm change. This is not an economy-tier consolidation pass like v2.2.
 - **Worker (executor):** MiniMax-M3 for bounded slices — node authoring against
-  a written interface, test authoring, docs. Every P1–P6 task is specified to be
+  a written interface, test authoring, docs. Every P1–P7 task is specified to be
   cheap-routable (concrete interface + verify command), per the verification-cost
   rule.
 - **Watcher / validator:** cross-family frontier, and **mandatory on P2 and P4**.
@@ -73,20 +73,47 @@ Per hard rule 9, frontier lanes are explicit-only — the seats below are a
 | **P3** | `graphs/pipeline.py` — the loop as a DAG, gates via `interrupt()` | `--autonomy medium` stops at each gate and resumes on `Command(resume=…)`; `high` does not stop; **bash lane still install-free** |
 | **P4** | ACN fan-out: `Send` dispatch, worktree subprocess executors, consolidation | 3-child batch runs concurrently; one child killed pre-meta ⇒ gate fails; main tree unmodified; **bash lane still install-free** |
 | **P5** | `bm --harness langgraph` + persistence + mermaid export | `--harness langgraph` preflights and runs a real goal; absent package exits 2 with an install hint, never a traceback; kill/resume completes; **bash lane still install-free** |
-| **P6** | Docs, adapter SKILL, parity tests, release | `test-acn-parity.sh` covers the Python state shape; `SKILL.md` v2.4.0; package builds; **bash lane still install-free** |
-| **P7** | `graphs/forever.py` — the continuous evolver + bounded topology mutation (separate effort) | Gated on P1–P6 |
-| **P8** | CrewAI binding (separate effort) | Gated on P7 |
+| **P6** | **Composability — the LangGraph-user surface**: importable nodes, subgraph embedding, state interop, `langgraph.json` / Studio | A user drops `provenance_gate` into *their own* graph; beastmode embeds as a subgraph in a foreign parent; `langgraph dev` opens it in Studio; **bash lane still install-free** |
+| **P7** | Docs, adapter SKILL, parity tests, release | `test-acn-parity.sh` covers the Python state shape; `SKILL.md` v2.4.0; package builds; **bash lane still install-free** |
+| **P8** | `graphs/forever.py` — the continuous evolver + bounded topology mutation (separate effort) | Gated on P1–P7 |
+| **P9** | CrewAI binding (separate effort) | Gated on P8 |
 
-P5 is where the **primary audience** gets served. If the effort has to stop
-early, stopping after P5 leaves beastmode users with a working upgrade;
-stopping after P4 leaves them with nothing they can invoke.
+**Two audiences, two finish lines.** P5 is where *beastmode users* get served —
+stop after P5 and they have a working upgrade; stop after P4 and they have
+nothing they can invoke. **P6 is where LangGraph users get served** — stop
+before it and the package is a monolithic take-it-or-leave-it graph that nobody
+with an existing LangGraph app can adopt, which forfeits the entire adoption
+thesis this effort exists for.
+
+### Cross-cutting requirements (apply to P3, P4 and P5 — not a separate phase)
+
+These are properties, not features, so they are built in rather than bolted on.
+Retrofitting any of them is a rewrite of every node.
+
+- **Async-first.** Nodes are `async def`; `ainvoke` / `astream` are the primary
+  path with sync wrappers over them. `AsyncPostgresSaver` / `AsyncSqliteSaver`
+  for the checkpointers. LangGraph deployments are async, and a sync-only
+  library is unusable inside one.
+- **Streaming.** `.stream()` and `astream_events` must produce useful output —
+  node-level progress, token streams from judgment seats, and subprocess stdout
+  from executor seats surfaced as custom stream events. A multi-hour
+  orchestrator that only returns a final value is unusable in practice, and it
+  is also how the phase report reaches a UI.
+- **Accept a `BaseChatModel` directly.** Alias resolution via
+  `tier-aliases.json` is a beastmode-ism. A LangGraph user already holds a
+  configured model instance; every seat must accept one, with alias resolution
+  as the convenience path, not the only path.
+- **Retry and idempotency.** Per-node `retry_policy` via `set_node_defaults`,
+  and a written statement of which nodes are safe to re-run. Gate nodes replay
+  on resume (P0.2); executor nodes must be idempotent against a half-finished
+  worktree.
 
 ---
 
 ## P0 — Spikes
 
 Throwaway code in a scratch worktree. Nothing merges. The deliverable is three
-written verdicts and one table. **This phase exists to make P1–P6 estimable**;
+written verdicts and one table. **This phase exists to make P1–P7 estimable**;
 skipping it means committing to a design whose central guarantee (drift
 detection) is unverified.
 
@@ -300,7 +327,72 @@ beastmode user types one flag and gets the upgrade.
 
 ---
 
-## P6 — Docs, parity, release
+## P6 — Composability: the LangGraph-user surface
+
+**Why this phase exists.** P1–P5 produce one prebuilt `build_pipeline()` graph.
+That serves a beastmode user (via `bm`) and a greenfield LangGraph user who is
+happy to adopt our whole topology. It serves **nobody who already has a
+LangGraph app** — and that is the population the adoption thesis is aimed at.
+A monolithic graph is take-it-or-leave-it; the ask was ready-to-use *patterns*
+people can copy into their own graphs.
+
+Without this phase the effort ships something technically complete and
+strategically pointless.
+
+**Scope**
+
+1. **Nodes as importable primitives.** Every node from P3 is exported and
+   independently usable in a foreign graph, with a documented signature and no
+   hidden dependency on the rest of the pipeline:
+   - `provenance_gate` — the drift/unverifiable check as a drop-in node
+   - `autonomy_gate(node)` — a wrapper that adds `interrupt()`-below-`high` to
+     *any* node, including the user's own
+   - `route_by_verification_cost` — the tier-routing rule as a conditional edge
+   - `acceptance_contract` / `mechanical_validation` / `judgment_review`
+   - `SeatModel` — usable standalone as a `BaseChatModel` wrapper that records
+     requested-vs-actual provenance on any call, in any graph
+2. **Subgraph embedding.** `build_pipeline()` compiles cleanly as a subgraph of
+   a foreign parent. Concretely: the checkpointer stays on the parent only (per
+   `REQUIREMENTS.md` §4), `interrupt()` still propagates to the parent's resume
+   path, and the beastmode phase report reaches the parent's stream.
+3. **State interop.** `BeastmodeState` is a *mixin over* a user's own state
+   schema, not a replacement for it. Documented reducers, a documented reserved
+   key prefix, and a test proving a user's unrelated state keys survive a full
+   beastmode run untouched.
+4. **Custom node injection.** Replace or wrap any seat's node — swap `review`
+   for your own reviewer, insert a node before `merge` — without forking the
+   package. A `build_pipeline(overrides={...})` seam plus a documented list of
+   which nodes are safe to replace and which are load-bearing (the gates are not
+   replaceable; that is the point of them).
+5. **`langgraph.json` + Studio.** Ship a `langgraph.json` so `langgraph dev`
+   picks the graphs up, and confirm the pipeline renders and steps in LangGraph
+   Studio. This is how LangGraph users actually inspect a graph, and it is the
+   real version of the "living flowchart" story — better than a static mermaid
+   file.
+6. **Templates, plural.** Not one worked example: a small set of copy-pasteable
+   patterns — minimal-gated-loop, ACN-fan-out-only, provenance-gate-only,
+   full-pipeline. The provenance-gate-only template is the cheapest possible
+   on-ramp and probably the most-used artifact in the whole effort.
+
+**Exit (deterministic)**
+- A test builds a **foreign** `StateGraph` (its own state schema, its own
+  nodes), drops in `provenance_gate` and `autonomy_gate`, and both behave
+  correctly — gate blocks below `high`, drift fails closed
+- A test embeds `build_pipeline()` as a subgraph of a foreign parent that owns
+  the checkpointer; an `interrupt()` inside the subgraph is resumable from the
+  parent
+- A user state key unrelated to beastmode survives a full run byte-identical
+- `build_pipeline(overrides={"review": my_node})` runs with the replacement;
+  attempting to override `gate_provenance` raises rather than silently allowing
+  it
+- `langgraph dev` serves the graphs; the pipeline renders in Studio
+- Each template in the docs is executed by a test, so no published example can
+  rot
+- **bash lane still install-free**
+
+---
+
+## P7 — Docs, parity, release
 
 **Scope**
 - `adapters/langgraph/SKILL.md`, matching the vocabulary of the other four
@@ -312,7 +404,8 @@ beastmode user types one flag and gets the upgrade.
 - `references/langgraph-pipeline.md` — the mermaid render + node/edge reference
 - A worked example: "Beastmode on LangGraph" evolving a small project, showing
   the PRD + priority list surviving a restart
-- `python/README.md` for the PyPI page
+- `python/README.md` for the PyPI page — leads with the P6 drop-in primitives,
+  not with `build_pipeline()`; the smallest on-ramp goes first
 
 **Exit (deterministic)**
 - `test-acn-parity.sh` gains: Python `ChildMeta` fields == schema
@@ -327,7 +420,7 @@ beastmode user types one flag and gets the upgrade.
 
 ---
 
-## P7 — `graphs/forever.py` (separate effort, gated)
+## P8 — `graphs/forever.py` (separate effort, gated)
 
 Not the same thing as P3, and worth stating plainly: P3 ports the *existing*
 fixed loop. P7 is the **new capability** — the continuously-cooking evolver that
@@ -371,11 +464,11 @@ section part of the P7 diff. Note that it is the first time an autonomy level
 grants a *capability* rather than merely suppressing a prompt — worth one more
 look before P7 starts.
 
-**Gated on:** P1–P6 shipped.
+**Gated on:** P1–P7 shipped.
 
 ---
 
-## P8 — CrewAI binding (separate effort, gated)
+## P9 — CrewAI binding (separate effort, gated)
 
 A `beastmode.crewai` binding over the same `beastmode.core`: Flows'
 `@start` / `@listen` / `@router` wrapping the same seats, contract, provenance
@@ -383,7 +476,7 @@ gate, and reports. Its exit criterion is that it adds **no** logic already in
 `core` — if it needs to reimplement the gate, P1's boundary failed and that is
 the finding.
 
-**Gated on:** P7, and a decision that CrewAI adoption is still worth it then.
+**Gated on:** P8, and a decision that CrewAI adoption is still worth it then.
 
 ---
 

--- a/.planning/langgraph/ROADMAP.md
+++ b/.planning/langgraph/ROADMAP.md
@@ -6,7 +6,24 @@ implementation on this branch). Implementation branches per phase, merged to
 
 Read `REQUIREMENTS.md` first — it holds the concept mapping, the LangGraph API
 facts each phase depends on, and the risk register phases P0–P2 exist to retire.
-Read `OPEN-QUESTIONS.md` before starting P1: **Q1–Q3 change this phase order**.
+
+**Decisions of 2026-08-03** (`OPEN-QUESTIONS.md` Q1, Q2, Q3, Q5) are folded in
+below. Q4 and Q6–Q10 remain open but do not block P0.
+
+> ### Invariant 0 — LangGraph is strictly additive
+>
+> **Beastmode works without LangGraph, exactly as it does today.** No bash
+> script, test, schema, doc, or adapter acquires a hard Python dependency;
+> `./tests/run-all.sh` passes with zero Python packages installed; no existing
+> `bm` invocation changes meaning. This outranks every other consideration in
+> this roadmap — where LangGraph idiom and this conflict, this wins. It appears
+> as a merge-blocking exit on **every** phase below, deliberately repeated, so
+> the dependency cannot leak in one phase at a time.
+>
+> Corollary: **existing beastmode users are the primary audience.**
+> `bm --harness langgraph` is a first-class deliverable. The package is the
+> implementation and the channel for LangGraph users arriving from the other
+> side; when the two audiences conflict, beastmode users win.
 
 ---
 
@@ -50,15 +67,19 @@ Per hard rule 9, frontier lanes are explicit-only — the seats below are a
 
 | Phase | Scope | Exit (deterministic) |
 |---|---|---|
-| **P0** | Spikes — retire the unknowns, throwaway code | Support matrix + 3 written verdicts (below) |
-| **P1** | `python/` skeleton, `beastmode.core`, schema loader, CI lane | `pytest` green; import-linter proves `core` has zero framework imports; `tests/run-all.sh` still passes with no Python deps installed |
-| **P2** | Seat layer + provenance: `SeatModel`, `ChildMeta`, drift gate | Every `acn_meta.py` fixture returns the identical verdict through the Python path; negative test per verdict |
-| **P3** | `graphs/pipeline.py` — the loop as a DAG, gates via `interrupt()` | A run at `--autonomy medium` stops at each gate and resumes on `Command(resume=…)`; at `high` it does not stop |
-| **P4** | ACN fan-out: `Send` dispatch, worktree subprocess executors, consolidation | 3-child batch runs concurrently; one child killed pre-meta ⇒ gate fails; main tree unmodified |
-| **P5** | Persistence, `bm --harness langgraph`, mermaid export | Kill mid-run, resume from checkpoint, run completes; `--harness langgraph` preflights and runs |
-| **P6** | Docs, adapter SKILL, parity tests, release | `test-acn-parity.sh` covers the Python state shape; `SKILL.md` v2.4.0; package builds |
-| **P7** | `graphs/forever.py` — the continuous evolver (separate effort) | Gated on P1–P6 + Q3 |
+| **P0** | Spikes — retire the unknowns, throwaway code | Support matrix + 3 written verdicts (below). **Gating**: P0.1 decides which seats may be direct-call |
+| **P1** | `python/` skeleton, `beastmode.core`, schema loader, CI lane | `pytest` green; import-linter proves `core` has zero framework imports; **`tests/run-all.sh` passes with no Python deps installed** |
+| **P2** | Seat layer + provenance: `SeatModel`, `ChildMeta`, drift gate | Every `acn_meta.py` fixture returns the identical verdict through the Python path; negative test per verdict; **bash lane still install-free** |
+| **P3** | `graphs/pipeline.py` — the loop as a DAG, gates via `interrupt()` | `--autonomy medium` stops at each gate and resumes on `Command(resume=…)`; `high` does not stop; **bash lane still install-free** |
+| **P4** | ACN fan-out: `Send` dispatch, worktree subprocess executors, consolidation | 3-child batch runs concurrently; one child killed pre-meta ⇒ gate fails; main tree unmodified; **bash lane still install-free** |
+| **P5** | `bm --harness langgraph` + persistence + mermaid export | `--harness langgraph` preflights and runs a real goal; absent package exits 2 with an install hint, never a traceback; kill/resume completes; **bash lane still install-free** |
+| **P6** | Docs, adapter SKILL, parity tests, release | `test-acn-parity.sh` covers the Python state shape; `SKILL.md` v2.4.0; package builds; **bash lane still install-free** |
+| **P7** | `graphs/forever.py` — the continuous evolver + bounded topology mutation (separate effort) | Gated on P1–P6 |
 | **P8** | CrewAI binding (separate effort) | Gated on P7 |
+
+P5 is where the **primary audience** gets served. If the effort has to stop
+early, stopping after P5 leaves beastmode users with a working upgrade;
+stopping after P4 leaves them with nothing they can invoke.
 
 ---
 
@@ -83,9 +104,15 @@ Classify each into:
 - **reports nothing** — same, `unverifiable`
 
 **Exit:** a `provider → provenance capability` matrix committed to
-`references/`, plus a one-paragraph verdict on whether direct-call nodes are
-viable at all or whether **every** executor must be a subprocess (which would
-make Q2 moot and simplify P4).
+`references/`, with a **`direct-call viable`** column per provider.
+
+This spike is now **gating**, because Q2 decided that judgment seats
+(director / watcher / validator) call chat models directly while executor seats
+stay subprocesses. Direct-call seats have no harness journal to fall back on —
+provider metadata is the only provenance they will ever have. Any frontier
+provider that lands in "echoes the alias" or "reports nothing" is demoted to a
+subprocess seat before P2 designs around it. If *no* frontier provider proves
+its model, the Q2 fallback applies and every seat becomes a subprocess.
 
 ### P0.2 — What does `interrupt()` replay actually cost? (retires risk 5.2)
 
@@ -242,7 +269,11 @@ The faithful port. Same eight steps, same gates, same reports — as a graph.
 
 ---
 
-## P5 — Persistence and the `bm` entrypoint
+## P5 — The `bm` entrypoint and persistence
+
+**The phase that serves the primary audience.** Everything before this is
+machinery only a LangGraph user could reach; this is where an existing
+beastmode user types one flag and gets the upgrade.
 
 **Scope**
 - `SqliteSaver` default, `PostgresSaver` opt-in (`.setup()` on first use;
@@ -255,11 +286,15 @@ The faithful port. Same eight steps, same gates, same reports — as a graph.
 - `bm --graph <name>` to choose `pipeline` (later `forever`)
 
 **Exit (deterministic)**
+- `bm "<goal>" --harness langgraph` runs a real goal end to end with the same
+  phase-report / gate / drift prompts as every other harness
+- `bm --harness langgraph` with the package absent exits 2 with an install hint,
+  never a traceback — and every *other* harness still works on that machine
+  (invariant 0, at the entrypoint where it is easiest to break)
+- `bm --harness bogus` still exits 2 (regression on `test-bm-model-check.sh`)
+- Every pre-existing `bm` invocation produces byte-identical behavior to `main`
 - Kill the process mid-phase; re-invoke with the same `thread_id`; the run
   resumes at the last checkpoint and completes
-- `bm --harness bogus` still exits 2 (regression on `test-bm-model-check.sh`)
-- `bm --harness langgraph` with the package absent exits 2 with an install hint,
-  never a traceback
 - Time-travel: replay from an earlier checkpoint produces a divergent thread
   without corrupting the original
 
@@ -311,10 +346,32 @@ New concerns this raises that P3 does not:
   anti-spin breaker (`pi-loop-police`'s role, with no LangGraph equivalent)
 - Supervision — checkpoints are not durable execution (`REQUIREMENTS.md` §5.5);
   an external supervisor is required before any "runs for days" claim is made
-- Whether the graph may edit its own topology (Q5) — currently forbidden by
-  hard rule "self-improvement writes notes only"
 
-**Gated on:** P1–P6 shipped, and Q3 answered.
+### Bounded topology mutation (decided — Q5)
+
+At `--autonomy high` **only**, the graph may rewrite its own topology. Below
+`high`, the existing rule holds unchanged: propose a diff, a human approves it.
+This loosens a rule the repo earned, so it ships with four guardrails:
+
+1. **A mutation may not remove or weaken a gate** — not `gate_provenance`, not
+   `gate_merge`, not the budget ceiling. `high` is precisely the mode where
+   nobody is watching, so a graph that can delete its own drift gate there is a
+   graph with no drift gate. Enforced by validating the post-mutation graph
+   against a required-node / required-edge set *before* `.compile()`, so an
+   illegal mutation cannot run even once.
+2. **Mutations are checkpointed and diffable** — pre-mutation topology
+   persisted, diff rendered as mermaid, both in the phase report.
+3. **Mutation is a surfacing event** — `topology_mutation` is added to
+   `high.always_surfaces` in `schema/autonomy-levels.json`, alongside
+   `budget_limited`. `high` never means silent.
+4. **Bounded per run** — a mutation counter with a ceiling.
+
+This makes `schema/autonomy-levels.json` and `SKILL.md`'s self-improvement
+section part of the P7 diff. Note that it is the first time an autonomy level
+grants a *capability* rather than merely suppressing a prompt — worth one more
+look before P7 starts.
+
+**Gated on:** P1–P6 shipped.
 
 ---
 
@@ -332,12 +389,18 @@ the finding.
 
 ## Success criteria for the effort
 
-- A LangGraph user runs `pip install beastmode-langgraph`, imports one builder,
-  and gets tier routing + contracts + drift gates + autonomy gating without
-  reading `SKILL.md`
-- The five invariants in `REQUIREMENTS.md` §2 hold, each asserted by a test that
-  was negative-tested by deliberately breaking it
-- `schema/*.json` is still the only source of truth; no field list exists twice
-- `scripts/lib/acn_meta.py` is still the only gate implementation
-- A bash-only beastmode user sees no change and installs nothing
-- `beastmode.core` has zero framework imports, proven by CI
+In priority order — the first one decides ties.
+
+1. **A bash-only beastmode user installs nothing and sees no change.**
+   Invariant 0. Asserted on every phase, not just at the end.
+2. **An existing beastmode user types `bm --harness langgraph` and gets an
+   upgrade** — the same loop, now with durable checkpoints, resumable runs,
+   `interrupt()`-backed gates, and an inspectable graph.
+3. A LangGraph user `pip install`s the package, imports one builder, and gets
+   tier routing + contracts + drift gates + autonomy gating without reading
+   `SKILL.md`.
+4. The invariants in `REQUIREMENTS.md` §2 hold, each asserted by a test that was
+   negative-tested by deliberately breaking it.
+5. `schema/*.json` is still the only source of truth; no field list exists twice.
+6. `scripts/lib/acn_meta.py` is still the only gate implementation.
+7. `beastmode.core` has zero framework imports, proven by CI.


### PR DESCRIPTION
## What this is

**Planning only — no implementation.** Four documents under `.planning/langgraph/` plus an index on `.planning/ROADMAP.md`, scoping beastmode v2.4.0: making beastmode usable as a LangGraph layer, while beastmode itself keeps working exactly as it does today without LangGraph.

| Doc | Holds |
|---|---|
| `REQUIREMENTS.md` | How each beastmode idea maps to a LangGraph feature (with a confidence column), the invariants a port must not lose, the LangGraph 1.2.x facts the design leans on, a ranked risk list, package layout |
| `ROADMAP.md` | P0 spikes → P7 release with deterministic exits; P8 (continuous evolver) and P9 (CrewAI) gated behind |
| `ACCEPTANCE.md` | Contract for P0–P7 — invariants each negative-tested, verification commands, escalation triggers |
| `OPEN-QUESTIONS.md` | Ten decisions; Q1/Q2/Q3/Q5 answered, Q4 and Q6–Q10 still open |

## The constraint that shaped everything

**Beastmode must keep working without LangGraph.** No bash script, test, schema, doc, or adapter picks up a Python dependency. `./tests/run-all.sh` passes with zero Python packages installed. Every existing `bm` command behaves identically.

This is invariant 0, and it's a merge-blocking exit on *every* phase — deliberately repeated, so the dependency can't creep in one phase at a time. Existing beastmode users are the primary audience; when the two audiences conflict, they win.

## Findings that drove the shape

**Knowing which model actually ran is the highest risk, and it's the headline guarantee.** LangGraph doesn't report which model served a call — only the provider's response data does, and not every provider reports the model it actually resolved to rather than the alias it was sent. Where it doesn't, every worker on that lane is `unverifiable` and the gate stays red. P0.1 measures this per provider *before* anything is built.

**Nodes running inside the orchestrator can't honor hard rule 1.** "Workers never commit/push", "never touch secrets", "stay in allowed paths" work today because the worker is a separate process with its own permission config and worktree. So LangGraph replaces `scripts/bm`'s control flow, not the executor: judgment seats call models directly, but every seat that writes files stays a subprocess in a worktree.

**CrewAI is paid for in phase 1 or paid twice later.** CrewAI Flows shares no shape with `StateGraph`; only a framework-neutral core transfers. Hence `beastmode.core` with zero framework imports, proven by CI rather than by review.

**A single prebuilt graph serves nobody who already uses LangGraph.** Found by auditing the first draft — it scoped one monolithic `build_pipeline()` and no way to use the pieces. P6 was added for that: importable nodes, subgraph embedding, state interop, `langgraph.json` / Studio, and templates. Stop before P6 and the package is technically complete and strategically pointless.

## Invariants carried forward

`schema/*.json` stays the single source of truth, and `scripts/lib/acn_meta.py` stays the only thing that decides pass/drift/unverifiable — the Python layer reads and calls them rather than restating them. Straight from `.learnings/BEASTMODE.md`: the v2.3 review found `schema/` called authoritative in four documents while no code read it, and found that same gate implemented twice with nothing asserting the two agreed.

Tracing follows the same rule: LangSmith may *display* a drift problem, never *decide* one. Tracing off, unreachable, or sampled must produce identical gate verdicts — negative-tested.

## Verification

`./tests/run-all.sh` — 6/6 green on every commit (syntax, JSON validity, phase-estimate self-test, ACN parity, `bm` model preflight, `bm` thinking passthrough). Working tree clean afterward. CI green.

## Not in this PR

No code. No `pyproject.toml`. No changes to `SKILL.md`, `README.md`, `schema/`, `scripts/`, or any adapter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only under `.planning/`; no runtime, CI, or dependency changes until later implementation phases.
> 
> **Overview**
> Adds **planning-only** documentation for beastmode **v2.4.0** as a LangGraph layer: four new files under `.planning/langgraph/` (`REQUIREMENTS.md`, `ROADMAP.md`, `ACCEPTANCE.md`, `OPEN-QUESTIONS.md`) and a **roadmap index** at the top of `.planning/ROADMAP.md` that points at ACN v2.2 (shipped), LangGraph (planning), and deferred CrewAI.
> 
> The docs lock **invariant 0**: LangGraph stays strictly additive—`./tests/run-all.sh` must pass with no Python packages; existing `bm` behavior unchanged until implementation lands. **Q1/Q2/Q3/Q5** are recorded as decided (dual audience via package + `bm --harness langgraph`; judgment seats direct-call vs file-writing executors as subprocesses in worktrees; pipeline before evolver; bounded topology mutation only at `high`).
> 
> **P0–P7** are spelled out with deterministic exits: spikes for `actual_model` provenance, package/`beastmode.core`, provenance gate parity with `acn_meta.py`, pipeline DAG with `interrupt()` gates, ACN `Send` fan-out, `bm` entrypoint, **P6 composability** (importable nodes, subgraph embedding, Studio), then docs/release. **P8** (`forever` evolver) and **P9** (CrewAI) stay gated.
> 
> No changes to `SKILL.md`, `schema/`, `scripts/`, adapters, or `pyproject.toml` in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b34b1388a88f1b96e987db85911da5ad047adae0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->