### PR TITLE
docs(planning): add run-visibility effort (acn-trace)

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -4,7 +4,8 @@
 |---|---|---|
 | ACN Unification (v2.2.0) | **shipped** — see below; hardened in v2.3.0 | this file, `ACCEPTANCE.md` |
 | Beastmode on LangGraph (v2.4.0) | **planning** — Q1/Q2/Q3/Q5 decided; P0 spikes ready to start | `langgraph/ROADMAP.md`, `langgraph/REQUIREMENTS.md`, `langgraph/ACCEPTANCE.md`, `langgraph/OPEN-QUESTIONS.md` |
-| CrewAI binding | **deferred** — gated on the LangGraph effort's P7 | `langgraph/ROADMAP.md` §P8 |
+| Run visibility (`acn-trace`) | **planned** — independent of LangGraph, works on every harness today | `observability/ROADMAP.md` |
+| CrewAI binding | **deferred** — gated on the LangGraph effort's evolver phase | `langgraph/ROADMAP.md` §P9 |
 
 ---
 

--- a/.planning/observability/ROADMAP.md
+++ b/.planning/observability/ROADMAP.md
@@ -1,0 +1,128 @@
+# ROADMAP — Run visibility (`acn-trace`)
+
+**Status:** planned, not started. Independent of the LangGraph effort — nothing
+here needs LangGraph, and it works on every harness beastmode already supports.
+
+## The problem
+
+Today you can't see what a beastmode run is doing. Work happens across parallel
+workers, the run finishes, and the only record is a pile of files on disk plus
+whatever scrolled past in the terminal. There's no place to look at a run
+afterwards, and no way to compare two runs.
+
+The LangGraph effort fixes this eventually, but it's several phases away and
+serves a different purpose. This is the short path.
+
+## The idea
+
+**Beastmode already collects everything needed. It just never sends it
+anywhere.**
+
+Every worker writes a `meta.json` receipt when it finishes — which model was
+asked for, which model actually ran, tokens used, how it stopped, which files it
+touched, which commands it ran, whether checks passed. `scripts/acn-report`
+already reads those into a text summary, and `scripts/lib/acn_meta.py` already
+classifies each one as pass / drift / unprovable.
+
+That receipt is, structurally, a trace entry. It has a model, a cost, and an
+outcome. Turning a directory of receipts into a run tree on LangSmith is a
+reading-and-posting job, not a new instrumentation project.
+
+**Three things fall out of that:**
+
+1. **It works today, on every harness** — hermes, pi, claude, codex. The
+   receipts don't care which one produced them.
+2. **It doesn't depend on LangGraph at all.** If the LangGraph effort slips or
+   gets dropped, this still works.
+3. **The privacy problem mostly disappears.** Receipts hold model names, token
+   counts, file paths, and pass/fail. No prompts, no diffs, no source code. This
+   is a much smaller thing to send off the machine than tracing a live graph
+   would be, which is exactly why it can ship sooner.
+
+## What ships
+
+`scripts/acn-trace <run-dir>` — a sibling of `acn-report`, taking the same
+input and reusing the same reader. Where `acn-report` renders text, `acn-trace`
+posts a run tree.
+
+Shape of what lands in LangSmith:
+
+- one parent entry per run or phase
+- one child entry per worker receipt, nested under it
+- details attached: goal id, phase, seat (director / watcher / executor),
+  harness, autonomy level, requested model, actual model, tokens
+- labels attached: `beastmode`, `seat:<name>`, and — the useful one —
+  `drift` or `unverifiable` whenever the gate didn't return a clean pass
+
+That last label is the payoff. "Show me every run last month where a worker
+used the wrong model" becomes a filter instead of a search across run
+directories.
+
+## Rules it must follow
+
+1. **Never load-bearing.** Tracing being off, broken, or unreachable must have
+   no effect on whether a run passes its gate. The gate stays
+   `scripts/lib/acn_meta.py` reading receipts off disk. A monitoring outage that
+   makes failing work look approved is the same class of bug the v2.3 review
+   closed twice — see `.learnings/BEASTMODE.md`.
+2. **Never required.** Beastmode works with no tracing configured and nothing
+   installed. `./tests/run-all.sh` keeps passing with zero Python packages
+   present. Missing credentials produce a clean skip, not an error.
+3. **One reader.** `acn-trace` calls `acn_meta.py` like the other two tools do.
+   A third way of parsing receipts would be the "one contract, two
+   implementations" problem again.
+4. **Nothing new for workers to write.** If this needs a field workers don't
+   already produce, that's a schema change and gets decided on its own merits
+   (see the timestamps question below) — not smuggled in.
+
+## Phases
+
+| Phase | Scope | Done when |
+|---|---|---|
+| **V0** | Decide the two open questions below | Written answers |
+| **V1** | `scripts/acn-trace <run-dir>`, run by hand after a run | A finished run appears in LangSmith with one entry per worker, correct models and token counts, drift labelled; missing credentials skip cleanly; `tests/run-all.sh` unaffected with nothing installed |
+| **V2** | `bm` calls it at phase close when tracing is switched on | A normal `bm` run shows up without any extra command; tracing off, broken, and pointed at a dead address all produce identical gate results (tested by deliberately breaking each) |
+| **V3** | Live view during the run, not only after | Workers appear as they finish rather than at the end. Hermes already writes live transcripts under `~/.hermes/cache/delegation/live/`, so it goes first; other harnesses follow if their runtimes expose the same |
+
+V1 is the whole point. V2 is convenience. V3 is optional and only worth doing if
+V1 turns out to get used.
+
+## Open questions
+
+**Q1 — Receipts have no timestamps.** A trace entry needs a start and an end.
+The required fields are id, requested model, actual model, stop reason, usage,
+files changed, commands run, and verify — no times. Options: (a) approximate
+from file modification time, which is rough but needs no schema change;
+(b) add optional `started_at` / `ended_at` to `schema/acn-contract.json` and
+have harness adapters fill them in. **Leaning (b) with (a) as fallback** —
+durations are most of the value of a trace, and "which worker was slow" is a
+question you'll want answered. But it touches the schema, so it's a real
+decision.
+
+**Q2 — Official SDK, or plain HTTP?** The LangSmith SDK is a Python package.
+Every other script in this repo runs on the standard library alone, which is
+why `tests/run-all.sh` needs no install. LangSmith also has a plain HTTP ingest
+endpoint. **Leaning plain HTTP** — it keeps the repo dependency-free, which is
+worth more than SDK convenience for a script this small. The cost is writing
+the request bodies by hand and tracking their format.
+
+**Q3 — Does it need to handle runs with no fan-out?** A single-worker run
+still produces a receipt. Probably yes and probably free, but worth confirming
+rather than discovering.
+
+**Q4 — Project naming.** One LangSmith project for all beastmode runs, or one
+per repo? Per-repo is likely right, but it affects how filters and comparisons
+work later.
+
+## Relationship to the LangGraph effort
+
+These don't compete; the second reuses the first.
+
+`.planning/langgraph/` already scopes reconstructing worker entries from
+receipts, because LangGraph has the same blind spot for exactly the same reason
+— the workers run as separate programs it can't see inside. Building
+`acn-trace` first means that phase becomes "call the existing tool" instead of
+"build a tracing layer".
+
+So this is worth doing even if the LangGraph work never starts, and it makes
+the LangGraph work smaller if it does.


### PR DESCRIPTION
## The problem

There's no way to see what a beastmode run did. Work happens across parallel workers, the run ends, and the record is a pile of files on disk plus whatever scrolled past in the terminal.

## The idea

**Beastmode already collects everything needed. It just never sends it anywhere.**

Every worker writes a `meta.json` receipt when it finishes — model asked for, model that actually ran, tokens, stop reason, files touched, commands run, whether checks passed. `acn-report` already renders those as text and `acn_meta.py` already classifies each as pass / drift / unprovable.

That receipt is structurally a trace entry: it has a model, a cost, and an outcome. Posting a directory of them as a run tree is a reading-and-posting job, not a new instrumentation project.

Three things follow:

- **Works today, on every harness** — hermes, pi, claude, codex. Receipts don't care which one produced them.
- **Needs nothing from the LangGraph effort**, so it survives that effort slipping or being dropped.
- **The privacy problem largely disappears.** Receipts carry no prompts, diffs, or source code — only model names, token counts, file paths, and pass/fail. Much smaller thing to send off the machine, which is why it can ship sooner.

## What's scoped

`scripts/acn-trace <run-dir>` — a sibling of `acn-report`, same input, same reader, posts instead of printing.

| Phase | Scope |
|---|---|
| V0 | Answer the two open questions |
| V1 | Run by hand after a run — **this is the point** |
| V2 | `bm` calls it at phase close when tracing is on |
| V3 | Live view rather than after-the-fact — optional |

Labels carry the payoff: `drift` / `unverifiable` stamped on any non-clean verdict, so "show me every run last month where a worker used the wrong model" becomes a filter instead of a search across run directories.

## Rules carried over from the last two releases

- **Never load-bearing.** Tracing off, broken, and pointed at a dead address must all produce identical gate verdicts — negative-tested. A monitoring outage that makes failing work look approved is the same class of bug the v2.3 review closed twice.
- **Never required.** `./tests/run-all.sh` keeps passing with zero Python packages installed; missing credentials skip cleanly.
- **One reader.** `acn-trace` calls `acn_meta.py` rather than parsing receipts a third way.
- **No new field for workers to write** without that being decided on its own merits.

## Open questions

**Receipts have no timestamps.** A trace entry needs a start and an end, and the required fields don't include times. Either approximate from file modification times, or add optional `started_at` / `ended_at` to the schema. Leaning the latter — durations are most of a trace's value — but it touches `schema/acn-contract.json`, so it's a real decision.

**SDK or plain HTTP?** Every script here runs on the standard library alone, which is why the test suite needs no install. Leaning plain HTTP to keep it that way.

## Relationship to the LangGraph effort

They don't compete — the second reuses the first. `.planning/langgraph/` already scopes rebuilding worker entries from receipts, because LangGraph has the same blind spot for the same reason: workers run as separate programs it can't see inside. Building this first turns that phase into "call the existing tool."

## Verification

`./tests/run-all.sh` — 6/6 green. Planning docs only; no code, no changes to scripts, schema, or adapters.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQwRiRXBpWzyZRD5WtYV2W)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only planning changes; no runtime, schema, or gate logic is modified in this PR.
> 
> **Overview**
> Adds a new **planned** effort for run visibility via **`acn-trace`**, documented in `.planning/observability/ROADMAP.md`, and registers it in the beastmode roadmap index alongside LangGraph and CrewAI.
> 
> The plan describes posting existing worker **`meta.json`** receipts (already read by **`acn-report`** / **`acn_meta.py`**) to LangSmith as a run tree—**`scripts/acn-trace <run-dir>`** as an **`acn-report`** sibling—without new worker instrumentation. Phases **V0–V3** cover open questions, manual post-run tracing, optional **`bm`** integration at phase close, and optional live updates. Constraints mirror v2.3 gate discipline: tracing must never affect gate verdicts, stay optional (stdlib / no required installs), and reuse **`acn_meta.py`** as the single receipt reader.
> 
> The index update also tweaks CrewAI deferral wording (LangGraph **evolver** phase / §P9 vs P7/P8).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba786d0b803f930872de73d9c4cc25115db9521b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->